### PR TITLE
feat: expand backend integrations and dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,99 @@
-# MindCare
+# SAMI 1
 
-MindCare es una app de bienestar mental construida con Flutter y Firebase.
+Cliente Flutter para el panel SAMI con soporte REST, WebSocket y modo offline-first.
 
-## Setup
+## Backend Setup
 
-1. Copiá `.env.sample` a `.env` y completá las variables necesarias.
-2. Ejecutá `flutter pub get`.
-3. Para Cloud Functions: `npm --prefix server/functions ci`.
+Configurar las variables de entorno en tiempo de compilación utilizando `--dart-define` (web/desktop/mobile). Ejemplos:
 
-## App Check y Stripe
-- Configurá Firebase App Check con la llave de sitio para web (`APP_CHECK_SITE_KEY`).
-- Añadí las claves de Stripe (`STRIPE_SECRET`, `STRIPE_WEBHOOK_SECRET`).
+```bash
+flutter run -d chrome \
+  --dart-define=BASE_URL=https://sami-dev.company.local \
+  --dart-define=WS_URL=wss://sami.company.com/ws \
+  --dart-define=ENV=dev
+```
 
-## Build
-- Android: `flutter build apk`
-- iOS: `flutter build ios`
-- Web: `flutter build web`
+Si no se indican valores, la app usa defaults seguros para `dev`/`prod`. Un `BASE_URL` vacío activa el modo demo con datos mock.
 
-Para más detalles de seguridad consultá [README_SECURITY.md](README_SECURITY.md).
+Variables disponibles:
 
-En iOS/macOS configurá Signing & Capabilities en Xcode antes de compilar.
+- `BASE_URL`
+- `WS_URL`
+- `MQTT_BROKER`
+- `ENV` (`dev`, `prod`, `demo`)
+
+## Autenticación
+
+Iniciar sesión con credenciales de backend (`username` + `password`). En modo demo se mantiene el usuario `ClaudioC / ABCD1234`.
+
+Tokens y refresh tokens se guardan usando `flutter_secure_storage` (mobile/desktop) y localStorage cifrado (web). La app refresca tokens de forma automática al recibir un `401`.
+
+## Modo Demo
+
+Si `BASE_URL` está vacío se habilitan datos mock, WebSocket simulado y se deshabilitan acciones críticas.
+
+## Offline y Sync
+
+- Isar como base local para cache y cola de outbox.
+- Cola de operaciones con retries exponenciales.
+- Detecta conectividad y fuerza sync al volver online.
+- Estrategia `cache-then-network` para listas.
+
+Para inspeccionar la cola offline se puede abrir la pantalla `/debug` (en desarrollo) y forzar un sync manual.
+
+## WebSocket y Alertas
+
+Al iniciar sesión se establece una conexión WS a `WS_URL`. Si falla, la app usa polling cada `alertsPollingInterval` (configurable por `dart-define`). En modo demo se generan alertas periódicas.
+
+## Módulos conectados
+
+- **Alertas:** consulta, resolución optimista y actualizaciones en vivo via WS/polling (`/alerts`, `/alerts/{id}`, `/alerts/{id}/resolve`).
+- **Cámaras:** listado con cache local y fallback demo (`/cameras`).
+- **Combustible:** historial con estrategia cache-then-network y KPI semanal (`/fuel/events`, `/fuel/kpis`).
+- **Herramientas:** estado de inventario y registro de movimientos con outbox offline (`/tools`, `/tools/movements`).
+- **Operarios:** gestión básica con creación/actualización offline (`/operators`).
+- **Proyectos:** alta y edición con sincronización automática (`/projects`).
+- **Reportes:** descarga de CSV con guardado local multiplataforma (`/reports/*`).
+- **Administración:** mantenimiento de usuarios/roles con guardas de rol (`/admin/users`, `/admin/roles`).
+
+## KPIs en Dashboard
+
+El panel principal muestra:
+
+- Alertas activas de las últimas 24hs.
+- Cámaras online.
+- Litros de combustible consumidos en la semana (`/fuel/kpis?range=week`).
+- Herramientas en uso en tiempo real.
+
+Desde cada tarjeta se puede navegar a los listados completos de alertas, combustible, herramientas y proyectos.
+
+## Reportes y Descargas
+
+Los endpoints CSV están integrados en `ReportsRepository`. En mobile/desktop se guardan en el directorio de documentos usando `path_provider`. En web la descarga es directa.
+
+## Scripts útiles
+
+- `flutter pub get`
+- `flutter pub run build_runner build --delete-conflicting-outputs` (para regenerar Isar si fuese necesario).
+- `flutter test`
+
+## Modo debug
+
+Ruta `/debug` (en desarrollo) para revisar:
+
+- Estado de conectividad.
+- Tamaño de la cola offline.
+- Último sync ejecutado.
+- Versión de la app.
+
+## Matriz de plataformas
+
+| Feature | Web | Mobile | Desktop |
+|---------|-----|--------|---------|
+| REST / Auth | ✅ | ✅ | ✅ |
+| WebSocket Alertas | ✅ | ✅ | ✅ |
+| Modo Offline | ⚠️ (limitado) | ✅ | ✅ |
+| Descarga Reportes | ✅ | ✅ | ✅ |
+| Almacenamiento seguro | Cifrado localStorage | Secure Storage | Secure Storage |
+
+> Nota: el modo offline en web está limitado por disponibilidad de APIs.

--- a/lib/bootstrap/app_bootstrap.dart
+++ b/lib/bootstrap/app_bootstrap.dart
@@ -1,0 +1,209 @@
+import '../core/config/app_config.dart';
+import '../core/database/cache_store.dart';
+import '../core/database/isar_database.dart';
+import '../core/logging/app_logger.dart';
+import '../core/network/http_client.dart';
+import '../core/offline/outbox_service.dart';
+import '../core/security/storage/secure_storage.dart';
+import '../core/security/token_storage.dart';
+import '../core/ws/alerts_realtime_service.dart';
+import '../data/alerts/alerts_repository_impl.dart';
+import '../data/alerts/datasources/alerts_local_data_source.dart';
+import '../data/alerts/datasources/alerts_remote_data_source.dart';
+import '../data/auth/auth_repository_impl.dart';
+import '../data/auth/datasources/auth_local_data_source.dart';
+import '../data/auth/datasources/auth_remote_data_source.dart';
+import '../data/cameras/cameras_repository_impl.dart';
+import '../data/cameras/datasources/cameras_local_data_source.dart';
+import '../data/cameras/datasources/cameras_remote_data_source.dart';
+import '../data/fuel/datasources/fuel_local_data_source.dart';
+import '../data/fuel/datasources/fuel_remote_data_source.dart';
+import '../data/fuel/fuel_repository_impl.dart';
+import '../data/tools/datasources/tools_local_data_source.dart';
+import '../data/tools/datasources/tools_remote_data_source.dart';
+import '../data/tools/tools_repository_impl.dart';
+import '../data/operators/datasources/operators_local_data_source.dart';
+import '../data/operators/datasources/operators_remote_data_source.dart';
+import '../data/operators/operators_repository_impl.dart';
+import '../data/projects/datasources/projects_local_data_source.dart';
+import '../data/projects/datasources/projects_remote_data_source.dart';
+import '../data/projects/projects_repository_impl.dart';
+import '../data/reports/reports_remote_data_source.dart';
+import '../data/reports/reports_repository_impl.dart';
+import '../data/admin/datasources/admin_local_data_source.dart';
+import '../data/admin/datasources/admin_remote_data_source.dart';
+import '../data/admin/admin_repository_impl.dart';
+import '../domain/auth/repositories/auth_repository.dart';
+import '../domain/cameras/cameras_repository.dart';
+import '../domain/fuel/fuel_repository.dart';
+import '../domain/tools/tools_repository.dart';
+import '../domain/operators/operators_repository.dart';
+import '../domain/projects/projects_repository.dart';
+import '../domain/reports/reports_repository.dart';
+import '../domain/admin/admin_repository.dart';
+import '../core/connectivity/connectivity_service.dart';
+
+class AppScope {
+  AppScope({
+    required this.config,
+    required this.httpClient,
+    required this.authRepository,
+    required this.alertsRepository,
+    required this.camerasRepository,
+    required this.fuelRepository,
+    required this.toolsRepository,
+    required this.operatorsRepository,
+    required this.projectsRepository,
+    required this.reportsRepository,
+    required this.adminRepository,
+    required this.alertsRealtimeService,
+    required this.outboxService,
+    required this.connectivityService,
+  });
+
+  final AppConfig config;
+  final AppHttpClient httpClient;
+  final AuthRepository authRepository;
+  final AlertsRepositoryImpl alertsRepository;
+  final CamerasRepository camerasRepository;
+  final FuelRepository fuelRepository;
+  final ToolsRepository toolsRepository;
+  final OperatorsRepository operatorsRepository;
+  final ProjectsRepository projectsRepository;
+  final ReportsRepository reportsRepository;
+  final AdminRepository adminRepository;
+  final AlertsRealtimeService alertsRealtimeService;
+  final OutboxService outboxService;
+  final ConnectivityService connectivityService;
+}
+
+class AppBootstrap {
+  static Future<AppScope> init() async {
+    final config = AppConfig.current;
+    final isar = await IsarDatabase.instance();
+    final cacheStore = CacheStore(isar);
+    final secureStorage = createSecureStorage();
+    final tokenStorage = TokenStorage(secureStorage);
+
+    final httpClient = AppHttpClient(config: config);
+
+    final authRemote = AuthRemoteDataSource(httpClient);
+    final authLocal = AuthLocalDataSource(tokenStorage);
+    final authRepository = AuthRepositoryImpl(
+      config,
+      authRemote,
+      authLocal,
+      AppLogger.instance,
+    );
+    httpClient.attachTokenManager(authRepository);
+
+    final alertsRemote = AlertsRemoteDataSource(httpClient);
+    final alertsLocal = AlertsLocalDataSource(isar);
+    final outboxService = OutboxService(
+      isar,
+      OutboxHttpExecutor(httpClient),
+      config,
+      AppLogger.instance,
+    );
+    final alertsRepository = AlertsRepositoryImpl(
+      alertsRemote,
+      alertsLocal,
+      config,
+      outboxService,
+      AppLogger.instance,
+    );
+
+    final camerasRemote = CamerasRemoteDataSource(httpClient);
+    final camerasLocal = CamerasLocalDataSource(cacheStore);
+    final camerasRepository = CamerasRepositoryImpl(
+      camerasRemote,
+      camerasLocal,
+      config,
+      AppLogger.instance,
+    );
+
+    final fuelRemote = FuelRemoteDataSource(httpClient);
+    final fuelLocal = FuelLocalDataSource(cacheStore);
+    final fuelRepository = FuelRepositoryImpl(
+      fuelRemote,
+      fuelLocal,
+      config,
+      outboxService,
+      AppLogger.instance,
+    );
+
+    final toolsRemote = ToolsRemoteDataSource(httpClient);
+    final toolsLocal = ToolsLocalDataSource(cacheStore);
+    final toolsRepository = ToolsRepositoryImpl(
+      toolsRemote,
+      toolsLocal,
+      config,
+      outboxService,
+      AppLogger.instance,
+    );
+
+    final operatorsRemote = OperatorsRemoteDataSource(httpClient);
+    final operatorsLocal = OperatorsLocalDataSource(cacheStore);
+    final operatorsRepository = OperatorsRepositoryImpl(
+      operatorsRemote,
+      operatorsLocal,
+      config,
+      outboxService,
+      AppLogger.instance,
+    );
+
+    final projectsRemote = ProjectsRemoteDataSource(httpClient);
+    final projectsLocal = ProjectsLocalDataSource(cacheStore);
+    final projectsRepository = ProjectsRepositoryImpl(
+      projectsRemote,
+      projectsLocal,
+      config,
+      outboxService,
+      AppLogger.instance,
+    );
+
+    final reportsRemote = ReportsRemoteDataSource(httpClient);
+    final reportsRepository = ReportsRepositoryImpl(
+      reportsRemote,
+      config,
+      AppLogger.instance,
+      null,
+    );
+
+    final adminRemote = AdminRemoteDataSource(httpClient);
+    final adminLocal = AdminLocalDataSource(cacheStore);
+    final adminRepository = AdminRepositoryImpl(
+      adminRemote,
+      adminLocal,
+      config,
+      outboxService,
+      AppLogger.instance,
+    );
+
+    final alertsRealtimeService = AlertsRealtimeService(
+      config,
+      httpClient,
+      AppLogger.instance,
+    );
+
+    final connectivityService = ConnectivityService();
+    await outboxService.start(connectivityService);
+
+    return AppScope(
+      config: config,
+      httpClient: httpClient,
+      authRepository: authRepository,
+      alertsRepository: alertsRepository,
+      camerasRepository: camerasRepository,
+      fuelRepository: fuelRepository,
+      toolsRepository: toolsRepository,
+      operatorsRepository: operatorsRepository,
+      projectsRepository: projectsRepository,
+      reportsRepository: reportsRepository,
+      adminRepository: adminRepository,
+      alertsRealtimeService: alertsRealtimeService,
+      outboxService: outboxService,
+      connectivityService: connectivityService,
+    );
+  }
+}

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,0 +1,163 @@
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+
+/// Supported runtime environments for the SAMI application.
+///
+/// The value is primarily used to pick default backend endpoints when
+/// dart-define overrides are not supplied.
+enum AppEnvironment { dev, prod, demo }
+
+/// Runtime configuration singleton that exposes resolved environment values.
+class AppConfig {
+  AppConfig._({
+    required this.environment,
+    required this.baseUrl,
+    required this.wsUrl,
+    required this.alertsPollingInterval,
+    this.mqttBroker,
+    this.syncInterval = const Duration(seconds: 30),
+  });
+
+  factory AppConfig.custom({
+    required AppEnvironment environment,
+    required String baseUrl,
+    required String wsUrl,
+    Duration alertsPollingInterval = const Duration(seconds: 25),
+    String? mqttBroker,
+    Duration syncInterval = const Duration(seconds: 30),
+  }) {
+    return AppConfig._(
+      environment: environment,
+      baseUrl: baseUrl,
+      wsUrl: wsUrl,
+      alertsPollingInterval: alertsPollingInterval,
+      mqttBroker: mqttBroker,
+      syncInterval: syncInterval,
+    );
+  }
+
+  /// The resolved environment, inferred from the ENV dart-define.
+  final AppEnvironment environment;
+
+  /// Base REST API url.
+  final String baseUrl;
+
+  /// WebSocket url used for realtime alerts.
+  final String wsUrl;
+
+  /// Optional MQTT broker endpoint.
+  final String? mqttBroker;
+
+  /// Interval used when falling back to polling alerts.
+  final Duration alertsPollingInterval;
+
+  /// Interval for running the offline outbox sync worker.
+  final Duration syncInterval;
+
+  static AppConfig? _instance;
+
+  /// Accessor to the resolved configuration.
+  static AppConfig get current => _instance ??= _loadFromEnvironment();
+
+  /// Allows overriding the configuration, mainly for tests.
+  static void override(AppConfig config) => _instance = config;
+
+  /// Indicates whether the application should run in demo mode.
+  bool get isDemoMode => baseUrl.isEmpty;
+
+  static AppConfig _loadFromEnvironment() {
+    const envName = String.fromEnvironment('ENV', defaultValue: 'prod');
+    final environment = _parseEnvironment(envName);
+
+    final baseUrl = const String.fromEnvironment('BASE_URL');
+    final wsUrl = const String.fromEnvironment('WS_URL');
+    final mqttBroker = const String.fromEnvironment('MQTT_BROKER');
+    final pollingSecondsString =
+        const String.fromEnvironment('ALERTS_POLLING_SECONDS');
+    final syncSecondsString =
+        const String.fromEnvironment('SYNC_WORKER_SECONDS');
+
+    final resolvedBaseUrl = baseUrl.isNotEmpty
+        ? baseUrl
+        : _defaultBaseUrl(environment) ?? '';
+
+    final resolvedWsUrl = wsUrl.isNotEmpty
+        ? wsUrl
+        : _defaultWsUrl(environment) ?? '';
+
+    final resolvedPolling = _safeDuration(
+      pollingSecondsString,
+      fallback: const Duration(seconds: 25),
+    );
+    final resolvedSync = _safeDuration(
+      syncSecondsString,
+      fallback: const Duration(seconds: 30),
+    );
+
+    final mqtt = mqttBroker.isNotEmpty ? mqttBroker : _defaultMqtt(environment);
+
+    return AppConfig._(
+      environment: environment,
+      baseUrl: resolvedBaseUrl,
+      wsUrl: resolvedWsUrl,
+      mqttBroker: mqtt,
+      alertsPollingInterval: resolvedPolling,
+      syncInterval: resolvedSync,
+    );
+  }
+
+  static AppEnvironment _parseEnvironment(String value) {
+    switch (value.toLowerCase()) {
+      case 'dev':
+      case 'development':
+        return AppEnvironment.dev;
+      case 'demo':
+        return AppEnvironment.demo;
+      default:
+        return AppEnvironment.prod;
+    }
+  }
+
+  static String? _defaultBaseUrl(AppEnvironment env) {
+    switch (env) {
+      case AppEnvironment.dev:
+        return 'https://sami-dev.company.local';
+      case AppEnvironment.prod:
+        return 'https://sami.company.com';
+      case AppEnvironment.demo:
+        return '';
+    }
+  }
+
+  static String? _defaultWsUrl(AppEnvironment env) {
+    switch (env) {
+      case AppEnvironment.dev:
+      case AppEnvironment.prod:
+        return 'wss://sami.company.com/ws';
+      case AppEnvironment.demo:
+        return '';
+    }
+  }
+
+  static String? _defaultMqtt(AppEnvironment env) {
+    switch (env) {
+      case AppEnvironment.dev:
+      case AppEnvironment.prod:
+        return 'mqtt.sami.company.com:8883';
+      case AppEnvironment.demo:
+        return null;
+    }
+  }
+
+  static Duration _safeDuration(String raw, {required Duration fallback}) {
+    if (raw.isEmpty) {
+      return fallback;
+    }
+    final parsed = int.tryParse(raw);
+    if (parsed == null || parsed < 1) {
+      return fallback;
+    }
+    return Duration(seconds: min(parsed, 600));
+  }
+}

--- a/lib/core/connectivity/connectivity_service.dart
+++ b/lib/core/connectivity/connectivity_service.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+enum ConnectivityStatus { online, offline }
+
+class ConnectivityService {
+  ConnectivityService() {
+    _subscription = Connectivity()
+        .onConnectivityChanged
+        .listen((result) => _controller.add(_fromResult(result)));
+  }
+
+  final _controller = StreamController<ConnectivityStatus>.broadcast();
+  StreamSubscription<ConnectivityResult>? _subscription;
+
+  Stream<ConnectivityStatus> get onStatusChanged => _controller.stream;
+
+  Future<ConnectivityStatus> currentStatus() async {
+    final result = await Connectivity().checkConnectivity();
+    return _fromResult(result);
+  }
+
+  ConnectivityStatus _fromResult(ConnectivityResult result) {
+    switch (result) {
+      case ConnectivityResult.bluetooth:
+      case ConnectivityResult.ethernet:
+      case ConnectivityResult.mobile:
+      case ConnectivityResult.vpn:
+      case ConnectivityResult.wifi:
+        return ConnectivityStatus.online;
+      default:
+        return ConnectivityStatus.offline;
+    }
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    await _controller.close();
+  }
+}

--- a/lib/core/database/cache_store.dart
+++ b/lib/core/database/cache_store.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+import 'package:isar/isar.dart';
+
+import 'entities.dart';
+
+class CacheStore {
+  CacheStore(this._isar);
+
+  final Isar _isar;
+
+  Future<void> saveAll(String type, List<Map<String, dynamic>> items) async {
+    await _isar.writeTxn(() async {
+      final query = _isar.cachedEntitys.buildQuery<CachedEntity>();
+      final existing = await query.findAll();
+      for (final entity in existing.where((element) => element.type == type)) {
+        await _isar.cachedEntitys.delete(entity.id);
+      }
+      for (final item in items) {
+        final entity = CachedEntity.create(
+          type: type,
+          entityId: item['id'].toString(),
+          data: jsonEncode(item),
+        );
+        await _isar.cachedEntitys.put(entity);
+      }
+    });
+  }
+
+  Future<void> saveOne(String type, String id, Map<String, dynamic> data) async {
+    await _isar.writeTxn(() async {
+      final entity = CachedEntity.create(
+        type: type,
+        entityId: id,
+        data: jsonEncode(data),
+      );
+      await _isar.cachedEntitys.put(entity);
+    });
+  }
+
+  Future<List<Map<String, dynamic>>> readAll(String type) async {
+    final query = _isar.cachedEntitys.buildQuery<CachedEntity>();
+    final items = await query.findAll();
+    return items
+        .where((element) => element.type == type)
+        .map((entity) => jsonDecode(entity.data) as Map<String, dynamic>)
+        .toList();
+  }
+
+  Future<Map<String, dynamic>?> readOne(String type, String id) async {
+    final query = _isar.cachedEntitys.buildQuery<CachedEntity>();
+    final items = await query.findAll();
+    final entity = items.firstWhere(
+      (element) => element.type == type && element.entityId == id,
+      orElse: () => CachedEntity.create(type: '', entityId: '', data: '{}'),
+    );
+    if (entity.type.isEmpty) {
+      return null;
+    }
+    return jsonDecode(entity.data) as Map<String, dynamic>;
+  }
+}

--- a/lib/core/database/entities.dart
+++ b/lib/core/database/entities.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:isar/isar.dart';
+
+part 'entities.g.dart';
+
+@collection
+class CachedEntity {
+  CachedEntity();
+
+  CachedEntity.create({
+    required this.type,
+    required this.entityId,
+    required this.data,
+    DateTime? updatedAt,
+  }) : updatedAt = updatedAt ?? DateTime.now() {
+    key = '${type}_$entityId';
+  }
+
+  Id id = Isar.autoIncrement;
+
+  String key = '';
+
+  String type = '';
+
+  String entityId = '';
+
+  String data = '';
+  DateTime? updatedAt;
+
+  Map<String, dynamic> toMap() => {
+        'type': type,
+        'entityId': entityId,
+        'data': data,
+        'updatedAt': updatedAt?.toIso8601String(),
+      };
+
+  static CachedEntity fromMap(Map<String, dynamic> map) => CachedEntity.create(
+        type: map['type'] as String,
+        entityId: map['entityId'] as String,
+        data: map['data'] as String,
+        updatedAt: map['updatedAt'] != null
+            ? DateTime.tryParse(map['updatedAt'] as String)
+            : null,
+      );
+}
+
+extension CachedEntityJson on CachedEntity {
+  Map<String, dynamic> decodeJson() => jsonDecode(data) as Map<String, dynamic>;
+}

--- a/lib/core/database/entities.g.dart
+++ b/lib/core/database/entities.g.dart
@@ -1,0 +1,125 @@
+// GENERATED CODE - MANUALLY WRITTEN FOR OFFLINE SUPPORT
+// ignore_for_file: public_member_api_docs
+
+part of 'entities.dart';
+
+extension GetCachedEntityCollection on Isar {
+  IsarCollection<CachedEntity> get cachedEntitys => collection<CachedEntity>();
+}
+
+const CachedEntitySchema = CollectionSchema(
+  name: r'CachedEntity',
+  id: 7936123458123456789,
+  properties: {
+    r'key': PropertySchema(
+      id: 0,
+      name: r'key',
+      type: IsarType.string,
+    ),
+    r'type': PropertySchema(
+      id: 1,
+      name: r'type',
+      type: IsarType.string,
+    ),
+    r'entityId': PropertySchema(
+      id: 2,
+      name: r'entityId',
+      type: IsarType.string,
+    ),
+    r'data': PropertySchema(
+      id: 3,
+      name: r'data',
+      type: IsarType.string,
+    ),
+    r'updatedAt': PropertySchema(
+      id: 4,
+      name: r'updatedAt',
+      type: IsarType.dateTime,
+    ),
+  },
+  estimateSize: _cachedEntityEstimateSize,
+  serialize: _cachedEntitySerialize,
+  deserialize: _cachedEntityDeserialize,
+  deserializeProp: _cachedEntityDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _cachedEntityGetId,
+  getLinks: _cachedEntityGetLinks,
+  attach: _cachedEntityAttach,
+  version: '3.1.0+1',
+);
+
+int _cachedEntityEstimateSize(
+  CachedEntity object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.key.length * 3;
+  bytesCount += 3 + object.type.length * 3;
+  bytesCount += 3 + object.entityId.length * 3;
+  bytesCount += 3 + object.data.length * 3;
+  return bytesCount;
+}
+
+void _cachedEntitySerialize(
+  CachedEntity object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.key);
+  writer.writeString(offsets[1], object.type);
+  writer.writeString(offsets[2], object.entityId);
+  writer.writeString(offsets[3], object.data);
+  writer.writeDateTime(offsets[4], object.updatedAt);
+}
+
+CachedEntity _cachedEntityDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = CachedEntity();
+  object.id = id;
+  object.key = reader.readString(offsets[0]);
+  object.type = reader.readString(offsets[1]);
+  object.entityId = reader.readString(offsets[2]);
+  object.data = reader.readString(offsets[3]);
+  object.updatedAt = reader.readDateTimeOrNull(offsets[4]);
+  return object;
+}
+
+P _cachedEntityDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return reader.readString(offset) as P;
+    case 1:
+      return reader.readString(offset) as P;
+    case 2:
+      return reader.readString(offset) as P;
+    case 3:
+      return reader.readString(offset) as P;
+    case 4:
+      return reader.readDateTimeOrNull(offset) as P;
+    default:
+      throw IsarError('Unknown property id');
+  }
+}
+
+Id _cachedEntityGetId(CachedEntity object) => object.id;
+
+List<IsarLinkBase<dynamic>> _cachedEntityGetLinks(CachedEntity object) => const [];
+
+void _cachedEntityAttach(
+    IsarCollection<dynamic> col, Id id, CachedEntity object) {
+  object.id = id;
+}

--- a/lib/core/database/isar_database.dart
+++ b/lib/core/database/isar_database.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/foundation.dart';
+import 'package:isar/isar.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../logging/app_logger.dart';
+import 'entities.dart';
+import '../offline/outbox_task.dart';
+
+class IsarDatabase {
+  IsarDatabase._();
+
+  static Isar? _isar;
+
+  static Future<Isar> instance() async {
+    if (_isar != null) {
+      return _isar!;
+    }
+    final schemas = [CachedEntitySchema, OutboxTaskSchema];
+    try {
+      if (kIsWeb) {
+        _isar = await Isar.open(
+          schemas,
+          inspector: kDebugMode,
+          name: 'sami',
+        );
+      } else {
+        final dir = await getApplicationSupportDirectory();
+        _isar = await Isar.open(
+          schemas,
+          inspector: kDebugMode,
+          directory: dir.path,
+          name: 'sami',
+        );
+      }
+    } catch (error, stackTrace) {
+      AppLogger.instance.error('Failed to open Isar', error, stackTrace);
+      rethrow;
+    }
+    return _isar!;
+  }
+}

--- a/lib/core/errors/app_error.dart
+++ b/lib/core/errors/app_error.dart
@@ -1,0 +1,30 @@
+/// Canonical error model used across the app layers.
+class AppError implements Exception {
+  const AppError(this.code, this.message, {this.cause});
+
+  final AppErrorCode code;
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => 'AppError(code: ${code.name}, message: $message)';
+}
+
+/// Standard error codes that map to backend/API failures as well as
+/// offline/validation states.
+enum AppErrorCode {
+  networkTimeout,
+  networkUnreachable,
+  unauthorized,
+  forbidden,
+  notFound,
+  validation,
+  serverError,
+  unknown,
+}
+
+extension AppErrorCodeX on AppErrorCode {
+  bool get isNetworkError =>
+      this == AppErrorCode.networkTimeout ||
+      this == AppErrorCode.networkUnreachable;
+}

--- a/lib/core/files/file_saver.dart
+++ b/lib/core/files/file_saver.dart
@@ -1,0 +1,9 @@
+import 'file_saver_stub.dart'
+    if (dart.library.io) 'file_saver_io.dart'
+    if (dart.library.html) 'file_saver_web.dart';
+
+abstract class FileSaver {
+  Future<String> saveBytes(String filename, List<int> bytes);
+}
+
+FileSaver createFileSaver() => createFileSaverImpl();

--- a/lib/core/files/file_saver_io.dart
+++ b/lib/core/files/file_saver_io.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import 'file_saver.dart';
+
+FileSaver createFileSaverImpl() => _IoFileSaver();
+
+class _IoFileSaver implements FileSaver {
+  @override
+  Future<String> saveBytes(String filename, List<int> bytes) async {
+    final directory = await getApplicationDocumentsDirectory();
+    final file = File('${directory.path}/$filename');
+    await file.writeAsBytes(bytes, flush: true);
+    return file.path;
+  }
+}

--- a/lib/core/files/file_saver_stub.dart
+++ b/lib/core/files/file_saver_stub.dart
@@ -1,0 +1,10 @@
+import 'file_saver.dart';
+
+FileSaver createFileSaverImpl() => _UnsupportedFileSaver();
+
+class _UnsupportedFileSaver implements FileSaver {
+  @override
+  Future<String> saveBytes(String filename, List<int> bytes) async {
+    return filename;
+  }
+}

--- a/lib/core/files/file_saver_web.dart
+++ b/lib/core/files/file_saver_web.dart
@@ -1,0 +1,20 @@
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+import 'file_saver.dart';
+
+FileSaver createFileSaverImpl() => _WebFileSaver();
+
+class _WebFileSaver implements FileSaver {
+  @override
+  Future<String> saveBytes(String filename, List<int> bytes) async {
+    final blob = html.Blob([Uint8List.fromList(bytes)]);
+    final url = html.Url.createObjectUrlFromBlob(blob);
+    final anchor = html.AnchorElement(href: url)
+      ..setAttribute('download', filename)
+      ..click();
+    html.Url.revokeObjectUrl(url);
+    return filename;
+  }
+}

--- a/lib/core/logging/app_logger.dart
+++ b/lib/core/logging/app_logger.dart
@@ -1,0 +1,29 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+/// Lightweight logger abstraction to make it easier to plug a more complex
+/// implementation in the future.
+class AppLogger {
+  const AppLogger._();
+
+  static const AppLogger instance = AppLogger._();
+
+  void debug(String message, [Object? error, StackTrace? stackTrace]) {
+    if (kDebugMode) {
+      developer.log(message, name: 'DEBUG', error: error, stackTrace: stackTrace);
+    }
+  }
+
+  void info(String message, [Object? error, StackTrace? stackTrace]) {
+    developer.log(message, name: 'INFO', error: error, stackTrace: stackTrace);
+  }
+
+  void warn(String message, [Object? error, StackTrace? stackTrace]) {
+    developer.log(message, name: 'WARN', error: error, stackTrace: stackTrace);
+  }
+
+  void error(String message, [Object? error, StackTrace? stackTrace]) {
+    developer.log(message, name: 'ERROR', error: error, stackTrace: stackTrace);
+  }
+}

--- a/lib/core/network/http_client.dart
+++ b/lib/core/network/http_client.dart
@@ -1,0 +1,363 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../config/app_config.dart';
+import '../errors/app_error.dart';
+import '../logging/app_logger.dart';
+import '../security/token_storage.dart';
+
+const _retryKey = 'sami.retry.count';
+const _refreshKey = 'sami.refresh.inflight';
+
+/// Contract used by [AppHttpClient] to interact with the auth layer for
+/// attaching/refreshing tokens during requests.
+abstract class AuthTokenManager {
+  Future<AuthTokens?> readTokens();
+
+  Future<bool> refreshToken();
+
+  void handleUnauthorized();
+}
+
+class AppHttpClient {
+  AppHttpClient({
+    required AppConfig config,
+    AppLogger logger = AppLogger.instance,
+    Duration connectTimeout = const Duration(seconds: 5),
+    Duration receiveTimeout = const Duration(seconds: 20),
+    int maxRetries = 3,
+  })  : _config = config,
+        _logger = logger,
+        _maxRetries = maxRetries {
+    final baseOptions = BaseOptions(
+      baseUrl: config.baseUrl,
+      connectTimeout: connectTimeout,
+      receiveTimeout: receiveTimeout,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+    );
+    dio = Dio(baseOptions);
+    _configureInterceptors();
+  }
+
+  final AppConfig _config;
+  final AppLogger _logger;
+  final int _maxRetries;
+  AuthTokenManager? _tokenManager;
+
+  late final Dio dio;
+
+  final _metrics = NetworkMetrics();
+
+  NetworkMetrics get metrics => _metrics;
+
+  void attachTokenManager(AuthTokenManager manager) {
+    _tokenManager = manager;
+  }
+
+  void _configureInterceptors() {
+    dio.interceptors.add(QueuedInterceptorsWrapper(
+      onRequest: (options, handler) async {
+        if (_tokenManager == null || _config.isDemoMode) {
+          handler.next(options);
+          return;
+        }
+        try {
+          final tokens = await _tokenManager!.readTokens();
+          final token = tokens?.accessToken;
+          if (token != null && token.isNotEmpty) {
+            options.headers['Authorization'] = 'Bearer $token';
+          }
+        } catch (error, stackTrace) {
+          _logger.warn('Failed to inject token', error, stackTrace);
+        }
+        handler.next(options);
+      },
+      onError: (error, handler) async {
+        if (_tokenManager == null || _config.isDemoMode) {
+          handler.next(error);
+          return;
+        }
+        if (error.response?.statusCode == 401 &&
+            error.requestOptions.extra[_refreshKey] != true) {
+          error.requestOptions.extra[_refreshKey] = true;
+          final refreshed = await _tokenManager!.refreshToken();
+          if (refreshed) {
+            try {
+              final cloned = _cloneRequest(error.requestOptions);
+              final response = await dio.fetch(cloned);
+              handler.resolve(response);
+              return;
+            } catch (retryError, stackTrace) {
+              _logger.error('Retry after refresh failed', retryError, stackTrace);
+            }
+          } else {
+            _tokenManager!.handleUnauthorized();
+          }
+        }
+        handler.next(error);
+      },
+    ));
+
+    dio.interceptors.add(_RetryInterceptor(dio, _maxRetries, _logger));
+
+    if (kDebugMode) {
+      dio.interceptors.add(LogInterceptor(
+        requestBody: true,
+        responseBody: true,
+        logPrint: (value) => _logger.debug(value.toString()),
+      ));
+    }
+  }
+
+  Future<Response<T>> get<T>(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    CancelToken? cancelToken,
+    ProgressCallback? onReceiveProgress,
+  }) {
+    return _run<T>(
+      () => dio.get<T>(
+        path,
+        queryParameters: queryParameters,
+        options: options,
+        cancelToken: cancelToken,
+        onReceiveProgress: onReceiveProgress,
+      ),
+    );
+  }
+
+  Future<Response<T>> post<T>(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    CancelToken? cancelToken,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) {
+    return _run<T>(
+      () => dio.post<T>(
+        path,
+        data: data,
+        queryParameters: queryParameters,
+        options: options,
+        cancelToken: cancelToken,
+        onReceiveProgress: onReceiveProgress,
+        onSendProgress: onSendProgress,
+      ),
+    );
+  }
+
+  Future<Response<T>> put<T>(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    CancelToken? cancelToken,
+  }) {
+    return _run<T>(
+      () => dio.put<T>(
+        path,
+        data: data,
+        queryParameters: queryParameters,
+        options: options,
+        cancelToken: cancelToken,
+      ),
+    );
+  }
+
+  Future<Response<T>> delete<T>(
+    String path, {
+    dynamic data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    CancelToken? cancelToken,
+  }) {
+    return _run<T>(
+      () => dio.delete<T>(
+        path,
+        data: data,
+        queryParameters: queryParameters,
+        options: options,
+        cancelToken: cancelToken,
+      ),
+    );
+  }
+
+  Future<Response<T>> _run<T>(
+    Future<Response<T>> Function() call,
+  ) async {
+    final stopwatch = Stopwatch()..start();
+    try {
+      final response = await call();
+      stopwatch.stop();
+      _metrics.recordSuccess(response.requestOptions, stopwatch.elapsed);
+      return response;
+    } on DioException catch (error) {
+      stopwatch.stop();
+      _metrics.recordFailure(error.requestOptions, stopwatch.elapsed);
+      throw _mapDioError(error);
+    }
+  }
+
+  AppError _mapDioError(DioException error) {
+    if (error.type == DioExceptionType.connectionTimeout ||
+        error.type == DioExceptionType.sendTimeout ||
+        error.type == DioExceptionType.receiveTimeout) {
+      return const AppError(
+        AppErrorCode.networkTimeout,
+        'La conexión tardó demasiado, por favor intentá nuevamente.',
+      );
+    }
+
+    if (error.type == DioExceptionType.badCertificate ||
+        error.type == DioExceptionType.connectionError ||
+        error.type == DioExceptionType.unknown) {
+      return AppError(
+        AppErrorCode.networkUnreachable,
+        'No se pudo conectar con el servidor.',
+        cause: error,
+      );
+    }
+
+    final response = error.response;
+    final status = response?.statusCode ?? 0;
+    final message = _extractMessage(response?.data) ??
+        'Ocurrió un error inesperado. ($status)';
+
+    switch (status) {
+      case 401:
+        return AppError(AppErrorCode.unauthorized, message, cause: error);
+      case 403:
+        return AppError(AppErrorCode.forbidden, message, cause: error);
+      case 404:
+        return AppError(AppErrorCode.notFound, message, cause: error);
+      case 409:
+      case 422:
+        return AppError(AppErrorCode.validation, message, cause: error);
+      case 500:
+      case 501:
+      case 503:
+        return AppError(AppErrorCode.serverError, message, cause: error);
+      default:
+        return AppError(AppErrorCode.unknown, message, cause: error);
+    }
+  }
+
+  String? _extractMessage(dynamic data) {
+    if (data is Map<String, dynamic>) {
+      final message = data['message'];
+      if (message is String) {
+        return message;
+      }
+      final error = data['error'];
+      if (error is String) {
+        return error;
+      }
+    }
+    return null;
+  }
+
+  RequestOptions _cloneRequest(RequestOptions options) {
+    return RequestOptions(
+      path: options.path,
+      method: options.method,
+      headers: Map<String, dynamic>.from(options.headers),
+      data: options.data,
+      queryParameters: Map<String, dynamic>.from(options.queryParameters),
+      extra: Map<String, dynamic>.from(options.extra),
+      baseUrl: options.baseUrl,
+      connectTimeout: options.connectTimeout,
+      receiveTimeout: options.receiveTimeout,
+      sendTimeout: options.sendTimeout,
+      responseType: options.responseType,
+      contentType: options.contentType,
+      followRedirects: options.followRedirects,
+      validateStatus: options.validateStatus,
+      receiveDataWhenStatusError: options.receiveDataWhenStatusError,
+      listFormat: options.listFormat,
+      requestEncoder: options.requestEncoder,
+      responseDecoder: options.responseDecoder,
+    );
+  }
+}
+
+class _RetryInterceptor extends Interceptor {
+  _RetryInterceptor(this._dio, this._maxRetries, this._logger);
+
+  final Dio _dio;
+  final int _maxRetries;
+  final AppLogger _logger;
+  final Random _random = Random();
+
+  @override
+  Future<void> onError(DioException err, ErrorInterceptorHandler handler) async {
+    final shouldRetry = _shouldRetry(err);
+    if (!shouldRetry) {
+      handler.next(err);
+      return;
+    }
+
+    final attempt = (err.requestOptions.extra[_retryKey] as int? ?? 0) + 1;
+    if (attempt > _maxRetries) {
+      handler.next(err);
+      return;
+    }
+
+    err.requestOptions.extra[_retryKey] = attempt;
+    final delay = _computeBackoff(attempt);
+    _logger.warn('Retrying request ${err.requestOptions.uri} in $delay');
+    await Future<void>.delayed(delay);
+    try {
+      final response = await _dio.fetch(err.requestOptions);
+      handler.resolve(response);
+    } on DioException catch (error) {
+      handler.next(error);
+    }
+  }
+
+  bool _shouldRetry(DioException error) {
+    if (error.type == DioExceptionType.badResponse) {
+      final status = error.response?.statusCode ?? 0;
+      return status >= 500;
+    }
+    return error.type == DioExceptionType.connectionError ||
+        error.type == DioExceptionType.connectionTimeout ||
+        error.type == DioExceptionType.receiveTimeout ||
+        error.type == DioExceptionType.sendTimeout;
+  }
+
+  Duration _computeBackoff(int attempt) {
+    final base = pow(2, attempt - 1).toInt();
+    final jitter = _random.nextInt(400);
+    return Duration(milliseconds: base * 500 + jitter);
+  }
+}
+
+class NetworkMetrics {
+  final ValueNotifier<int> _successCount = ValueNotifier<int>(0);
+  final ValueNotifier<int> _failureCount = ValueNotifier<int>(0);
+  final ValueNotifier<Duration> _lastDuration =
+      ValueNotifier<Duration>(Duration.zero);
+
+  ValueListenable<int> get successCount => _successCount;
+  ValueListenable<int> get failureCount => _failureCount;
+  ValueListenable<Duration> get lastDuration => _lastDuration;
+
+  void recordSuccess(RequestOptions options, Duration duration) {
+    _successCount.value++;
+    _lastDuration.value = duration;
+  }
+
+  void recordFailure(RequestOptions options, Duration duration) {
+    _failureCount.value++;
+    _lastDuration.value = duration;
+  }
+}

--- a/lib/core/offline/outbox_service.dart
+++ b/lib/core/offline/outbox_service.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:dio/dio.dart';
+import 'package:isar/isar.dart';
+
+import '../config/app_config.dart';
+import '../connectivity/connectivity_service.dart';
+import '../errors/app_error.dart';
+import '../logging/app_logger.dart';
+import '../network/http_client.dart';
+import 'outbox_task.dart';
+
+abstract class OutboxNetworkExecutor {
+  Future<void> execute(OutboxTask task);
+}
+
+class OutboxHttpExecutor implements OutboxNetworkExecutor {
+  OutboxHttpExecutor(this._client);
+
+  final AppHttpClient _client;
+
+  @override
+  Future<void> execute(OutboxTask task) async {
+    final headers = task.decodedHeaders();
+    final data = task.payload.isNotEmpty ? jsonDecode(task.payload) : null;
+    switch (task.method.toUpperCase()) {
+      case 'POST':
+        await _client.post(task.endpoint, data: data, options: Options(headers: headers));
+        break;
+      case 'PUT':
+      case 'PATCH':
+        await _client.put(task.endpoint, data: data, options: Options(headers: headers));
+        break;
+      case 'DELETE':
+        await _client.delete(task.endpoint, data: data, options: Options(headers: headers));
+        break;
+      default:
+        await _client.post(task.endpoint, data: data, options: Options(headers: headers));
+    }
+  }
+}
+
+class OutboxService {
+  OutboxService(
+    this._isar,
+    this._executor,
+    this._config,
+    this._logger,
+  );
+
+  final Isar _isar;
+  final OutboxNetworkExecutor _executor;
+  final AppConfig _config;
+  final AppLogger _logger;
+
+  Timer? _timer;
+  StreamSubscription<ConnectivityStatus>? _connectivitySub;
+  bool _processing = false;
+
+  Future<void> start(ConnectivityService connectivity) async {
+    _timer ??= Timer.periodic(_config.syncInterval, (_) => processPending());
+    _connectivitySub ??= connectivity.onStatusChanged.listen((status) {
+      if (status == ConnectivityStatus.online) {
+        processPending();
+      }
+    });
+  }
+
+  Future<void> dispose() async {
+    await _connectivitySub?.cancel();
+    _connectivitySub = null;
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  Future<OutboxTask> enqueue({
+    required String method,
+    required String endpoint,
+    Map<String, dynamic>? body,
+    Map<String, String>? headers,
+    String? reference,
+    DateTime? retryAt,
+  }) async {
+    final task = OutboxTask()
+      ..method = method
+      ..endpoint = endpoint
+      ..payload = body != null ? jsonEncode(body) : ''
+      ..headers = headers != null ? jsonEncode(headers) : null
+      ..reference = reference
+      ..status = OutboxStatus.pending
+      ..retryAt = retryAt
+      ..createdAt = DateTime.now();
+
+    await _isar.writeTxn(() async {
+      await _isar.outboxTasks.put(task);
+    });
+    return task;
+  }
+
+  Future<List<OutboxTask>> allTasks() async {
+    final query = _isar.outboxTasks.buildQuery<OutboxTask>();
+    return query.findAll();
+  }
+
+  Future<void> processPending() async {
+    if (_processing) {
+      return;
+    }
+    _processing = true;
+    try {
+      final now = DateTime.now();
+      final tasks = await allTasks();
+      final queue = tasks
+          .where(
+            (task) => task.status != OutboxStatus.completed &&
+                task.status != OutboxStatus.failed &&
+                (task.retryAt == null || task.retryAt!.isBefore(now)),
+          )
+          .sorted((a, b) => a.createdAt.compareTo(b.createdAt));
+      for (final task in queue) {
+        await _executeTask(task);
+      }
+    } finally {
+      _processing = false;
+    }
+  }
+
+  Future<void> _executeTask(OutboxTask task) async {
+    try {
+      await _executor.execute(task);
+      await _markCompleted(task);
+    } on AppError catch (error, stackTrace) {
+      _logger.warn('Outbox task failed', error, stackTrace);
+      if (error.code.isNetworkError) {
+        await _scheduleRetry(task);
+      } else {
+        await _markFailed(task, error.message);
+      }
+    } catch (error, stackTrace) {
+      _logger.error('Unexpected outbox error', error, stackTrace);
+      await _markFailed(task, error.toString());
+    }
+  }
+
+  Future<void> _markCompleted(OutboxTask task) async {
+    await _isar.writeTxn(() async {
+      task
+        ..status = OutboxStatus.completed
+        ..retryAt = null;
+      await _isar.outboxTasks.put(task);
+    });
+  }
+
+  Future<void> _scheduleRetry(OutboxTask task) async {
+    final attempts = task.attempts + 1;
+    final delaySeconds = (1 << attempts).clamp(2, 300);
+    final retryAt = DateTime.now().add(Duration(seconds: delaySeconds));
+    await _isar.writeTxn(() async {
+      task
+        ..attempts = attempts
+        ..status = OutboxStatus.retrying
+        ..retryAt = retryAt;
+      await _isar.outboxTasks.put(task);
+    });
+  }
+
+  Future<void> _markFailed(OutboxTask task, String reason) async {
+    await _isar.writeTxn(() async {
+      task
+        ..status = OutboxStatus.failed
+        ..retryAt = null;
+      await _isar.outboxTasks.put(task);
+    });
+  }
+}

--- a/lib/core/offline/outbox_task.dart
+++ b/lib/core/offline/outbox_task.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:isar/isar.dart';
+
+part 'outbox_task.g.dart';
+
+enum OutboxStatus { pending, retrying, completed, failed }
+
+@collection
+class OutboxTask {
+  OutboxTask();
+
+  Id id = Isar.autoIncrement;
+
+  String method = 'POST';
+  String endpoint = '';
+  String payload = '';
+  String? headers;
+  String? reference;
+  int attempts = 0;
+
+  DateTime createdAt = DateTime.now();
+  DateTime? retryAt;
+
+  @enumerated
+  OutboxStatus status = OutboxStatus.pending;
+
+  Map<String, dynamic> toJson() => {
+        'method': method,
+        'endpoint': endpoint,
+        'payload': payload,
+        'headers': headers,
+        'reference': reference,
+        'attempts': attempts,
+        'createdAt': createdAt.toIso8601String(),
+        'retryAt': retryAt?.toIso8601String(),
+        'status': status.name,
+      };
+
+  static OutboxTask fromJson(Map<String, dynamic> json) {
+    final task = OutboxTask();
+    task.method = json['method'] as String? ?? 'POST';
+    task.endpoint = json['endpoint'] as String? ?? '';
+    task.payload = json['payload'] as String? ?? '';
+    task.headers = json['headers'] as String?;
+    task.reference = json['reference'] as String?;
+    task.attempts = json['attempts'] as int? ?? 0;
+    task.createdAt = DateTime.tryParse(json['createdAt'] as String? ?? '') ??
+        DateTime.now();
+    task.retryAt = json['retryAt'] != null
+        ? DateTime.tryParse(json['retryAt'] as String)
+        : null;
+    final status = json['status'] as String?;
+    task.status = OutboxStatus.values.firstWhere(
+      (value) => value.name == status,
+      orElse: () => OutboxStatus.pending,
+    );
+    return task;
+  }
+
+  Map<String, String> decodedHeaders() {
+    if (headers == null || headers!.isEmpty) {
+      return <String, String>{};
+    }
+    try {
+      final map = jsonDecode(headers!) as Map<String, dynamic>;
+      return map.map(
+        (key, value) => MapEntry(key, value?.toString() ?? ''),
+      );
+    } catch (_) {
+      return <String, String>{};
+    }
+  }
+}

--- a/lib/core/offline/outbox_task.g.dart
+++ b/lib/core/offline/outbox_task.g.dart
@@ -1,0 +1,174 @@
+// GENERATED CODE - MANUALLY WRITTEN FOR OFFLINE SUPPORT
+// ignore_for_file: public_member_api_docs
+
+part of 'outbox_task.dart';
+
+extension GetOutboxTaskCollection on Isar {
+  IsarCollection<OutboxTask> get outboxTasks => collection<OutboxTask>();
+}
+
+const OutboxTaskSchema = CollectionSchema(
+  name: r'OutboxTask',
+  id: 6753342051123456789,
+  properties: {
+    r'method': PropertySchema(
+      id: 0,
+      name: r'method',
+      type: IsarType.string,
+    ),
+    r'endpoint': PropertySchema(
+      id: 1,
+      name: r'endpoint',
+      type: IsarType.string,
+    ),
+    r'payload': PropertySchema(
+      id: 2,
+      name: r'payload',
+      type: IsarType.string,
+    ),
+    r'headers': PropertySchema(
+      id: 3,
+      name: r'headers',
+      type: IsarType.string,
+    ),
+    r'reference': PropertySchema(
+      id: 4,
+      name: r'reference',
+      type: IsarType.string,
+    ),
+    r'attempts': PropertySchema(
+      id: 5,
+      name: r'attempts',
+      type: IsarType.long,
+    ),
+    r'createdAt': PropertySchema(
+      id: 6,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'retryAt': PropertySchema(
+      id: 7,
+      name: r'retryAt',
+      type: IsarType.dateTime,
+    ),
+    r'status': PropertySchema(
+      id: 8,
+      name: r'status',
+      type: IsarType.byte,
+      enumMap: {
+        'pending': 0,
+        'retrying': 1,
+        'completed': 2,
+        'failed': 3,
+      },
+    ),
+  },
+  estimateSize: _outboxTaskEstimateSize,
+  serialize: _outboxTaskSerialize,
+  deserialize: _outboxTaskDeserialize,
+  deserializeProp: _outboxTaskDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _outboxTaskGetId,
+  getLinks: _outboxTaskGetLinks,
+  attach: _outboxTaskAttach,
+  version: '3.1.0+1',
+);
+
+int _outboxTaskEstimateSize(
+  OutboxTask object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.method.length * 3;
+  bytesCount += 3 + object.endpoint.length * 3;
+  bytesCount += 3 + object.payload.length * 3;
+  final headers = object.headers;
+  if (headers != null) {
+    bytesCount += 3 + headers.length * 3;
+  }
+  final reference = object.reference;
+  if (reference != null) {
+    bytesCount += 3 + reference.length * 3;
+  }
+  return bytesCount;
+}
+
+void _outboxTaskSerialize(
+  OutboxTask object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.method);
+  writer.writeString(offsets[1], object.endpoint);
+  writer.writeString(offsets[2], object.payload);
+  writer.writeString(offsets[3], object.headers);
+  writer.writeString(offsets[4], object.reference);
+  writer.writeLong(offsets[5], object.attempts);
+  writer.writeDateTime(offsets[6], object.createdAt);
+  writer.writeDateTime(offsets[7], object.retryAt);
+  writer.writeByte(offsets[8], object.status.index);
+}
+
+OutboxTask _outboxTaskDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = OutboxTask();
+  object.id = id;
+  object.method = reader.readString(offsets[0]);
+  object.endpoint = reader.readString(offsets[1]);
+  object.payload = reader.readString(offsets[2]);
+  object.headers = reader.readStringOrNull(offsets[3]);
+  object.reference = reader.readStringOrNull(offsets[4]);
+  object.attempts = reader.readLong(offsets[5]);
+  object.createdAt = reader.readDateTime(offsets[6]);
+  object.retryAt = reader.readDateTimeOrNull(offsets[7]);
+  final statusIndex = reader.readByte(offsets[8]);
+  object.status = OutboxStatus.values[statusIndex];
+  return object;
+}
+
+P _outboxTaskDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return reader.readString(offset) as P;
+    case 1:
+      return reader.readString(offset) as P;
+    case 2:
+      return reader.readString(offset) as P;
+    case 3:
+      return reader.readStringOrNull(offset) as P;
+    case 4:
+      return reader.readStringOrNull(offset) as P;
+    case 5:
+      return reader.readLong(offset) as P;
+    case 6:
+      return reader.readDateTime(offset) as P;
+    case 7:
+      return reader.readDateTimeOrNull(offset) as P;
+    case 8:
+      return OutboxStatus.values[reader.readByte(offset)] as P;
+    default:
+      throw IsarError('Unknown property id');
+  }
+}
+
+Id _outboxTaskGetId(OutboxTask object) => object.id;
+
+List<IsarLinkBase<dynamic>> _outboxTaskGetLinks(OutboxTask object) => const [];
+
+void _outboxTaskAttach(IsarCollection<dynamic> col, Id id, OutboxTask object) {
+  object.id = id;
+}

--- a/lib/core/router/new_app_router.dart
+++ b/lib/core/router/new_app_router.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../../features/admin/users/admin_users_screen.dart';
+import '../../features/alerts/presentation/alerts_list_screen.dart';
+import '../../features/auth/controllers/auth_controller.dart';
+import '../../features/auth/presentation/login_screen.dart';
+import '../../features/dashboard/dashboard_screen.dart';
+import '../../features/fuel/fuel_screen.dart';
+import '../../features/tools/tools_screen.dart';
+import '../../features/operators/operators_screen.dart';
+import '../../features/projects/projects_screen.dart';
+import '../../domain/auth/entities/app_user.dart';
+
+class AppRouter {
+  static GoRouter create(AuthController authController) {
+    return GoRouter(
+      initialLocation: '/login',
+      refreshListenable: authController,
+      redirect: (context, state) {
+        final loggedIn = authController.isAuthenticated;
+        final loggingIn = state.fullPath == '/login';
+        if (!loggedIn) {
+          return loggingIn ? null : '/login';
+        }
+        if (loggingIn) {
+          return '/dashboard';
+        }
+        return null;
+      },
+      routes: [
+        GoRoute(
+          path: '/login',
+          builder: (context, state) => const LoginScreen(),
+        ),
+        GoRoute(
+          path: '/dashboard',
+          builder: (context, state) => const DashboardScreen(),
+        ),
+        GoRoute(
+          path: '/alerts',
+          builder: (context, state) => const AlertsListScreen(),
+        ),
+        GoRoute(
+          path: '/fuel',
+          builder: (context, state) => const FuelScreen(),
+        ),
+        GoRoute(
+          path: '/tools',
+          builder: (context, state) => const ToolsScreen(),
+        ),
+        GoRoute(
+          path: '/operators',
+          builder: (context, state) => const OperatorsScreen(),
+        ),
+        GoRoute(
+          path: '/projects',
+          builder: (context, state) => const ProjectsScreen(),
+        ),
+        GoRoute(
+          path: '/admin/users',
+          builder: (context, state) {
+            final controller = context.read<AuthController>();
+            if (controller.session?.user.role != UserRole.admin) {
+              return const AccessDeniedScreen();
+            }
+            return const AdminUsersScreen();
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class AccessDeniedScreen extends StatelessWidget {
+  const AccessDeniedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Acceso denegado'),
+      ),
+    );
+  }
+}

--- a/lib/core/security/storage/secure_storage.dart
+++ b/lib/core/security/storage/secure_storage.dart
@@ -1,0 +1,16 @@
+import 'secure_storage_stub.dart'
+    if (dart.library.io) 'secure_storage_mobile.dart'
+    if (dart.library.html) 'secure_storage_web.dart';
+
+/// Abstraction over secure persistence for secrets such as tokens.
+abstract class SecureStorage {
+  Future<void> write(String key, String value);
+
+  Future<String?> read(String key);
+
+  Future<void> delete(String key);
+
+  Future<void> clear();
+}
+
+SecureStorage createSecureStorage() => createSecureStorageImpl();

--- a/lib/core/security/storage/secure_storage_mobile.dart
+++ b/lib/core/security/storage/secure_storage_mobile.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'secure_storage.dart';
+
+class SecureStorageMobile implements SecureStorage {
+  SecureStorageMobile()
+      : _storage = const FlutterSecureStorage(
+          aOptions: AndroidOptions(encryptedSharedPreferences: true),
+        );
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<void> clear() => _storage.deleteAll();
+
+  @override
+  Future<void> delete(String key) => _storage.delete(key: key);
+
+  @override
+  Future<String?> read(String key) => _storage.read(key: key);
+
+  @override
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+}
+
+SecureStorage createSecureStorageImpl() => SecureStorageMobile();

--- a/lib/core/security/storage/secure_storage_stub.dart
+++ b/lib/core/security/storage/secure_storage_stub.dart
@@ -1,0 +1,5 @@
+import 'secure_storage.dart';
+
+SecureStorage createSecureStorageImpl() => throw UnsupportedError(
+      'Secure storage is not supported on this platform',
+    );

--- a/lib/core/security/storage/secure_storage_web.dart
+++ b/lib/core/security/storage/secure_storage_web.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+import 'dart:html' as html;
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:encrypt/encrypt.dart' as encrypt;
+
+import 'secure_storage.dart';
+
+class SecureStorageWeb implements SecureStorage {
+  SecureStorageWeb()
+      : _encrypter = encrypt.Encrypter(
+          encrypt.Salsa20(_deriveKey()),
+        );
+
+  static final Random _random = Random.secure();
+  static const int _nonceLength = 8;
+  static final String _seed = 'sami-web-storage-seed';
+
+  final encrypt.Encrypter _encrypter;
+
+  @override
+  Future<void> clear() async => html.window.localStorage.clear();
+
+  @override
+  Future<void> delete(String key) async => html.window.localStorage.remove(key);
+
+  @override
+  Future<String?> read(String key) async {
+    final encoded = html.window.localStorage[key];
+    if (encoded == null) {
+      return null;
+    }
+    try {
+      final raw = base64Decode(encoded);
+      if (raw.length <= _nonceLength) {
+        return null;
+      }
+      final nonce = raw.sublist(0, _nonceLength);
+      final cipherBytes = raw.sublist(_nonceLength);
+      final decrypted = _encrypter.decrypt(
+        encrypt.Encrypted(cipherBytes),
+        iv: encrypt.IV(Uint8List.fromList(nonce)),
+      );
+      return decrypted;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    final nonce = List<int>.generate(_nonceLength, (_) => _random.nextInt(255));
+    final encrypted = _encrypter.encrypt(
+      value,
+      iv: encrypt.IV(Uint8List.fromList(nonce)),
+    );
+    final payload = Uint8List(nonce.length + encrypted.bytes.length)
+      ..setRange(0, nonce.length, nonce)
+      ..setRange(nonce.length, nonce.length + encrypted.bytes.length,
+          encrypted.bytes);
+    html.window.localStorage[key] = base64Encode(payload);
+  }
+
+  static encrypt.Key _deriveKey() {
+    final hash = crypto.sha256.convert(utf8.encode(_seed));
+    return encrypt.Key(Uint8List.fromList(hash.bytes));
+  }
+}
+
+SecureStorage createSecureStorageImpl() => SecureStorageWeb();

--- a/lib/core/security/token_storage.dart
+++ b/lib/core/security/token_storage.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+
+import '../errors/app_error.dart';
+import 'storage/secure_storage.dart';
+
+/// Persisted tokens container.
+class AuthTokens {
+  const AuthTokens({required this.accessToken, required this.refreshToken});
+
+  final String accessToken;
+  final String refreshToken;
+
+  Map<String, dynamic> toJson() => {
+        'token': accessToken,
+        'refreshToken': refreshToken,
+      };
+
+  factory AuthTokens.fromJson(Map<String, dynamic> json) {
+    final token = json['token'] as String?;
+    final refresh = json['refreshToken'] as String?;
+    if (token == null || refresh == null) {
+      throw const AppError(AppErrorCode.validation, 'Invalid token payload');
+    }
+    return AuthTokens(accessToken: token, refreshToken: refresh);
+  }
+}
+
+/// Storage for persisting and retrieving auth tokens securely.
+class TokenStorage {
+  TokenStorage(this._secureStorage);
+
+  final SecureStorage _secureStorage;
+
+  static const String _key = 'sami.auth.tokens';
+
+  Future<void> save(AuthTokens tokens) async {
+    final encoded = jsonEncode(tokens.toJson());
+    await _secureStorage.write(_key, encoded);
+  }
+
+  Future<AuthTokens?> read() async {
+    final raw = await _secureStorage.read(_key);
+    if (raw == null) {
+      return null;
+    }
+    try {
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      return AuthTokens.fromJson(json);
+    } catch (error) {
+      await _secureStorage.delete(_key);
+      return null;
+    }
+  }
+
+  Future<void> clear() => _secureStorage.delete(_key);
+}
+
+extension AuthTokensX on AuthTokens {
+  bool get isNotEmpty =>
+      accessToken.isNotEmpty && refreshToken.isNotEmpty;
+
+  bool get isEmpty => !isNotEmpty;
+
+  static AuthTokens? fromMap(Map<String, dynamic>? map) {
+    if (map == null) {
+      return null;
+    }
+    final token = map['token'];
+    final refresh = map['refreshToken'];
+    if (token is String && refresh is String) {
+      return AuthTokens(accessToken: token, refreshToken: refresh);
+    }
+    return null;
+  }
+
+  Map<String, String> asHeaders() => {
+        'Authorization': 'Bearer $accessToken',
+      };
+}

--- a/lib/core/ws/alerts_realtime_service.dart
+++ b/lib/core/ws/alerts_realtime_service.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import '../config/app_config.dart';
+import '../logging/app_logger.dart';
+import '../network/http_client.dart';
+
+typedef AlertMessageHandler = FutureOr<void> Function(Map<String, dynamic>);
+
+class AlertsRealtimeService {
+  AlertsRealtimeService(
+    this._config,
+    this._client,
+    this._logger,
+  );
+
+  final AppConfig _config;
+  final AppHttpClient _client;
+  final AppLogger _logger;
+
+  WebSocketChannel? _channel;
+  StreamSubscription? _subscription;
+  Timer? _pollingTimer;
+  bool _closing = false;
+  String? _token;
+  DateTime? _lastTimestamp;
+  AlertMessageHandler? _handler;
+  Future<void> start({
+    required String token,
+    required AlertMessageHandler onMessage,
+  }) async {
+    _token = token;
+    _handler = onMessage;
+    if (_config.isDemoMode) {
+      _startDemoStream();
+      return;
+    }
+    if (_config.wsUrl.isEmpty) {
+      _startPolling();
+      return;
+    }
+    await _connectWebSocket();
+  }
+
+  Future<void> _connectWebSocket() async {
+    try {
+      final uri = Uri.parse(_config.wsUrl);
+      final wsUri = uri.replace(
+        queryParameters: {
+          ...uri.queryParameters,
+          'token': _token ?? '',
+        },
+      );
+      _channel = WebSocketChannel.connect(wsUri);
+      _subscription = _channel!.stream.listen(
+        (event) {
+          if (_handler == null) {
+            return;
+          }
+          try {
+            if (event is String) {
+              final decoded = jsonDecode(event) as Map<String, dynamic>;
+              _handler!(decoded);
+              final createdAt = decoded['createdAt'] as String?;
+              if (createdAt != null) {
+                final ts = DateTime.tryParse(createdAt);
+                if (ts != null) {
+                  _lastTimestamp = ts;
+                }
+              }
+            }
+          } catch (error, stackTrace) {
+            _logger.warn('Error parsing WS alert', error, stackTrace);
+          }
+        },
+        onError: (error, stackTrace) {
+          _logger.warn('WS alerts error', error, stackTrace);
+          _fallbackToPolling();
+        },
+        onDone: () {
+          if (!_closing) {
+            _fallbackToPolling();
+          }
+        },
+      );
+    } catch (error, stackTrace) {
+      _logger.warn('Failed to connect to websocket', error, stackTrace);
+      _fallbackToPolling();
+    }
+  }
+
+  void _fallbackToPolling() {
+    _subscription?.cancel();
+    _subscription = null;
+    _channel?.sink.close();
+    _channel = null;
+    _scheduleReconnect();
+  }
+
+  void _scheduleReconnect() {
+    _pollingTimer?.cancel();
+    _pollingTimer = Timer.periodic(
+      _config.alertsPollingInterval,
+      (_) => _pollAlerts(),
+    );
+    _pollAlerts();
+  }
+
+  void _startPolling() {
+    _pollingTimer?.cancel();
+    _pollingTimer = Timer.periodic(
+      _config.alertsPollingInterval,
+      (_) => _pollAlerts(),
+    );
+    _pollAlerts();
+  }
+
+  void _startDemoStream() {
+    _pollingTimer?.cancel();
+    _pollingTimer = Timer.periodic(
+      const Duration(seconds: 30),
+      (_) {
+        if (_handler == null) {
+          return;
+        }
+        final now = DateTime.now();
+        final payload = {
+          'id': 'demo-${now.millisecondsSinceEpoch}',
+          'type': 'Alerta demo',
+          'severity': 'medium',
+          'source': 'system',
+          'createdAt': now.toIso8601String(),
+          'payload': {'demo': true},
+        };
+        _handler!(payload);
+      },
+    );
+  }
+
+  Future<void> _pollAlerts() async {
+    if (_handler == null) {
+      return;
+    }
+    final params = <String, dynamic>{};
+    if (_lastTimestamp != null) {
+      params['since'] = _lastTimestamp!.toIso8601String();
+    }
+    try {
+      final response = await _client.get<List<dynamic>>(
+        '/alerts',
+        queryParameters: params,
+      );
+      final data = response.data ?? const [];
+      for (final item in data.whereType<Map<String, dynamic>>()) {
+        await _handler!(item);
+        final createdAt = item['createdAt'] as String?;
+        if (createdAt != null) {
+          final ts = DateTime.tryParse(createdAt);
+          if (ts != null) {
+            _lastTimestamp = ts;
+          }
+        }
+      }
+    } catch (error, stackTrace) {
+      _logger.warn('Alerts polling failed', error, stackTrace);
+    }
+  }
+
+  Future<void> stop() async {
+    _closing = true;
+    await _subscription?.cancel();
+    _subscription = null;
+    await _channel?.sink.close();
+    _channel = null;
+    _pollingTimer?.cancel();
+    _pollingTimer = null;
+  }
+}

--- a/lib/data/admin/admin_repository_impl.dart
+++ b/lib/data/admin/admin_repository_impl.dart
@@ -1,0 +1,250 @@
+import 'package:uuid/uuid.dart';
+
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/logging/app_logger.dart';
+import '../../core/offline/outbox_service.dart';
+import '../../domain/admin/admin_repository.dart';
+import '../../domain/admin/user_account.dart';
+import '../../domain/auth/entities/app_user.dart';
+import 'datasources/admin_local_data_source.dart';
+import 'datasources/admin_remote_data_source.dart';
+import 'models/admin_user_dto.dart';
+import 'models/role_permissions_dto.dart';
+
+class AdminRepositoryImpl implements AdminRepository {
+  AdminRepositoryImpl(
+    this._remote,
+    this._local,
+    this._config,
+    this._outbox,
+    this._logger,
+  );
+
+  final AdminRemoteDataSource _remote;
+  final AdminLocalDataSource _local;
+  final AppConfig _config;
+  final OutboxService _outbox;
+  final AppLogger _logger;
+  final _uuid = const Uuid();
+
+  List<AdminUserAccount> _cachedUsers = <AdminUserAccount>[];
+  List<RolePermissions> _cachedRoles = <RolePermissions>[];
+
+  @override
+  Future<List<AdminUserAccount>> fetchUsers() async {
+    final cached = await _local.loadUsers();
+    if (_cachedUsers.isEmpty && cached.isNotEmpty) {
+      _cachedUsers = cached.map((dto) => dto.toDomain()).toList();
+    }
+
+    if (_config.isDemoMode) {
+      _cachedUsers = _demoUsers;
+      return _cachedUsers;
+    }
+
+    try {
+      final dtos = await _remote.fetchUsers();
+      await _local.cacheUsers(dtos);
+      _cachedUsers = dtos.map((dto) => dto.toDomain()).toList();
+      return _cachedUsers;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch admin users', error);
+      if (_cachedUsers.isNotEmpty && error.code.isNetworkError) {
+        return _cachedUsers;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<AdminUserAccount> createUser({
+    required String username,
+    required String displayName,
+    required UserRole role,
+  }) async {
+    final user = AdminUserAccount(
+      id: _uuid.v4(),
+      username: username,
+      displayName: displayName,
+      role: role,
+    );
+
+    if (_config.isDemoMode) {
+      _cachedUsers = [..._cachedUsers, user];
+      await _local.cacheUsers(
+        _cachedUsers.map(AdminUserDto.fromDomain).toList(),
+      );
+      return user;
+    }
+
+    final body = {
+      'username': username,
+      'displayName': displayName,
+      'role': role.name,
+    };
+    try {
+      final dto = await _remote.createUser(body);
+      await _local.upsertUser(dto);
+      final domain = dto.toDomain();
+      _cachedUsers = [..._cachedUsers, domain];
+      return domain;
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        _cachedUsers = [..._cachedUsers, user];
+        await _local.cacheUsers(
+          _cachedUsers.map(AdminUserDto.fromDomain).toList(),
+        );
+        await _outbox.enqueue(
+          method: 'POST',
+          endpoint: '/admin/users',
+          body: body,
+          reference: user.id,
+        );
+        return user;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<AdminUserAccount> updateUser(String id, Map<String, dynamic> updates) async {
+    if (_config.isDemoMode) {
+      _cachedUsers = _cachedUsers
+          .map(
+            (user) => user.id == id
+                ? AdminUserAccount(
+                    id: user.id,
+                    username: updates['username'] as String? ?? user.username,
+                    displayName:
+                        updates['displayName'] as String? ?? user.displayName,
+                    role: updates['role'] != null
+                        ? UserRole.values.firstWhere(
+                            (value) => value.name ==
+                                (updates['role'] as String).toLowerCase(),
+                            orElse: () => user.role,
+                          )
+                        : user.role,
+                    disabled: updates['disabled'] as bool? ?? user.disabled,
+                  )
+                : user,
+          )
+          .toList();
+      await _local.cacheUsers(
+        _cachedUsers.map(AdminUserDto.fromDomain).toList(),
+      );
+      return _cachedUsers.firstWhere((user) => user.id == id);
+    }
+
+    try {
+      final dto = await _remote.updateUser(id, updates);
+      await _local.upsertUser(dto);
+      final domain = dto.toDomain();
+      _cachedUsers = _cachedUsers
+          .map((user) => user.id == id ? domain : user)
+          .toList();
+      return domain;
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        await _outbox.enqueue(
+          method: 'PATCH',
+          endpoint: '/admin/users/$id',
+          body: updates,
+          reference: id,
+        );
+        return _cachedUsers.firstWhere((user) => user.id == id);
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> disableUser(String id) async {
+    if (_config.isDemoMode) {
+      _cachedUsers = _cachedUsers
+          .map((user) => user.id == id
+              ? AdminUserAccount(
+                  id: user.id,
+                  username: user.username,
+                  displayName: user.displayName,
+                  role: user.role,
+                  disabled: true,
+                )
+              : user)
+          .toList();
+      await _local.cacheUsers(
+        _cachedUsers.map(AdminUserDto.fromDomain).toList(),
+      );
+      return;
+    }
+    try {
+      await _remote.disableUser(id);
+      _cachedUsers = _cachedUsers
+          .map((user) => user.id == id
+              ? AdminUserAccount(
+                  id: user.id,
+                  username: user.username,
+                  displayName: user.displayName,
+                  role: user.role,
+                  disabled: true,
+                )
+              : user)
+          .toList();
+      await _local.cacheUsers(
+        _cachedUsers.map(AdminUserDto.fromDomain).toList(),
+      );
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        await _outbox.enqueue(
+          method: 'POST',
+          endpoint: '/admin/users/$id/disable',
+          body: const {},
+          reference: id,
+        );
+      } else {
+        rethrow;
+      }
+    }
+  }
+
+  @override
+  Future<List<RolePermissions>> fetchRoles() async {
+    if (_cachedRoles.isNotEmpty) {
+      return _cachedRoles;
+    }
+    if (_config.isDemoMode) {
+      _cachedRoles = _demoRoles;
+      return _cachedRoles;
+    }
+    try {
+      final dtos = await _remote.fetchRoles();
+      _cachedRoles = dtos.map((dto) => dto.toDomain()).toList();
+      return _cachedRoles;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch role permissions', error);
+      rethrow;
+    }
+  }
+
+  List<AdminUserAccount> get _demoUsers => <AdminUserAccount>[
+        AdminUserAccount(
+          id: 'admin-1',
+          username: 'admin',
+          displayName: 'Administrador',
+          role: UserRole.admin,
+        ),
+        AdminUserAccount(
+          id: 'sup-1',
+          username: 'supervisor',
+          displayName: 'Supervisor',
+          role: UserRole.supervisor,
+        ),
+      ];
+
+  List<RolePermissions> get _demoRoles => <RolePermissions>[
+        RolePermissions(role: UserRole.admin, permissions: {'users': true, 'projects': true}),
+        RolePermissions(role: UserRole.supervisor, permissions: {'users': false, 'projects': true}),
+        RolePermissions(role: UserRole.operario, permissions: {'users': false, 'projects': false}),
+        RolePermissions(role: UserRole.viewer, permissions: {'users': false, 'projects': false}),
+      ];
+}

--- a/lib/data/admin/datasources/admin_local_data_source.dart
+++ b/lib/data/admin/datasources/admin_local_data_source.dart
@@ -1,0 +1,26 @@
+import '../../../core/database/cache_store.dart';
+import '../models/admin_user_dto.dart';
+
+class AdminLocalDataSource {
+  AdminLocalDataSource(this._cacheStore);
+
+  final CacheStore _cacheStore;
+
+  static const _usersType = 'admin_users';
+
+  Future<void> cacheUsers(List<AdminUserDto> users) async {
+    await _cacheStore.saveAll(
+      _usersType,
+      users.map((dto) => dto.toJson()).toList(),
+    );
+  }
+
+  Future<void> upsertUser(AdminUserDto user) async {
+    await _cacheStore.saveOne(_usersType, user.id, user.toJson());
+  }
+
+  Future<List<AdminUserDto>> loadUsers() async {
+    final cached = await _cacheStore.readAll(_usersType);
+    return cached.map(AdminUserDto.fromJson).toList();
+  }
+}

--- a/lib/data/admin/datasources/admin_remote_data_source.dart
+++ b/lib/data/admin/datasources/admin_remote_data_source.dart
@@ -1,0 +1,47 @@
+import '../../../core/network/http_client.dart';
+import '../models/admin_user_dto.dart';
+import '../models/role_permissions_dto.dart';
+
+class AdminRemoteDataSource {
+  AdminRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<List<AdminUserDto>> fetchUsers() async {
+    final response = await _client.get<List<dynamic>>('/admin/users');
+    final data = response.data ?? const [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(AdminUserDto.fromJson)
+        .toList();
+  }
+
+  Future<AdminUserDto> createUser(Map<String, dynamic> body) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/admin/users',
+      data: body,
+    );
+    return AdminUserDto.fromJson(response.data ?? const {});
+  }
+
+  Future<AdminUserDto> updateUser(String id, Map<String, dynamic> body) async {
+    final response = await _client.patch<Map<String, dynamic>>(
+      '/admin/users/$id',
+      data: body,
+    );
+    return AdminUserDto.fromJson(response.data ?? const {});
+  }
+
+  Future<void> disableUser(String id) async {
+    await _client.post('/admin/users/$id/disable');
+  }
+
+  Future<List<RolePermissionsDto>> fetchRoles() async {
+    final response = await _client.get<List<dynamic>>('/admin/roles');
+    final data = response.data ?? const [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(RolePermissionsDto.fromJson)
+        .toList();
+  }
+}

--- a/lib/data/admin/models/admin_user_dto.dart
+++ b/lib/data/admin/models/admin_user_dto.dart
@@ -1,0 +1,59 @@
+import '../../../domain/admin/user_account.dart';
+import '../../../domain/auth/entities/app_user.dart';
+
+class AdminUserDto {
+  AdminUserDto({
+    required this.id,
+    required this.username,
+    required this.displayName,
+    required this.role,
+    this.disabled = false,
+  });
+
+  final String id;
+  final String username;
+  final String displayName;
+  final String role;
+  final bool disabled;
+
+  factory AdminUserDto.fromJson(Map<String, dynamic> json) {
+    return AdminUserDto(
+      id: json['id'].toString(),
+      username: json['username'] as String? ?? '',
+      displayName: json['displayName'] as String? ?? '',
+      role: (json['role'] as String? ?? 'viewer').toLowerCase(),
+      disabled: json['disabled'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'username': username,
+        'displayName': displayName,
+        'role': role,
+        'disabled': disabled,
+      };
+
+  AdminUserAccount toDomain() {
+    return AdminUserAccount(
+      id: id,
+      username: username,
+      displayName: displayName,
+      role: UserRole.values.firstWhere(
+        (value) => value.name == role,
+        orElse: () => UserRole.viewer,
+      ),
+      disabled: disabled,
+    );
+  }
+
+  static AdminUserDto fromDomain(AdminUserAccount account) {
+    return AdminUserDto(
+      id: account.id,
+      username: account.username,
+      displayName: account.displayName,
+      role: account.role.name,
+      disabled: account.disabled,
+    );
+  }
+}

--- a/lib/data/admin/models/role_permissions_dto.dart
+++ b/lib/data/admin/models/role_permissions_dto.dart
@@ -1,0 +1,32 @@
+import '../../../domain/admin/user_account.dart';
+import '../../../domain/auth/entities/app_user.dart';
+
+class RolePermissionsDto {
+  RolePermissionsDto({required this.role, required this.permissions});
+
+  final String role;
+  final Map<String, bool> permissions;
+
+  factory RolePermissionsDto.fromJson(Map<String, dynamic> json) {
+    return RolePermissionsDto(
+      role: (json['role'] as String? ?? 'viewer').toLowerCase(),
+      permissions: (json['permissions'] as Map<String, dynamic>? ?? const {})
+          .map((key, value) => MapEntry(key, value == true)),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'role': role,
+        'permissions': permissions,
+      };
+
+  RolePermissions toDomain() {
+    return RolePermissions(
+      role: UserRole.values.firstWhere(
+        (value) => value.name == role,
+        orElse: () => UserRole.viewer,
+      ),
+      permissions: permissions,
+    );
+  }
+}

--- a/lib/data/alerts/alerts_repository_impl.dart
+++ b/lib/data/alerts/alerts_repository_impl.dart
@@ -1,0 +1,205 @@
+import 'dart:async';
+
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/logging/app_logger.dart';
+import '../../domain/alerts/alert.dart';
+import '../../domain/alerts/alerts_repository.dart';
+import '../../core/offline/outbox_service.dart';
+import 'datasources/alerts_local_data_source.dart';
+import 'datasources/alerts_remote_data_source.dart';
+import 'models/alert_dto.dart';
+
+class AlertsRepositoryImpl implements AlertsRepository {
+  AlertsRepositoryImpl(
+    this._remote,
+    this._local,
+    this._config,
+    this._outbox,
+    this._logger,
+  );
+
+  final AlertsRemoteDataSource _remote;
+  final AlertsLocalDataSource _local;
+  final AppConfig _config;
+  final OutboxService _outbox;
+  final AppLogger _logger;
+
+  final _controller = StreamController<List<Alert>>.broadcast();
+  bool _initialized = false;
+  List<Alert> _current = <Alert>[];
+
+  void _ensureInitialized() {
+    if (_initialized) {
+      return;
+    }
+    _initialized = true;
+    _loadCached();
+  }
+
+  Future<void> _loadCached() async {
+    final cachedDtos = await _local.loadAlerts();
+    final alerts = cachedDtos.map((dto) => dto.toDomain()).toList();
+    if (alerts.isNotEmpty) {
+      _current = alerts;
+      _controller.add(alerts);
+    }
+  }
+
+  @override
+  Stream<List<Alert>> watchAlerts() {
+    _ensureInitialized();
+    return _controller.stream;
+  }
+
+  @override
+  Future<List<Alert>> fetchAlerts({
+    DateTime? from,
+    DateTime? to,
+    String? severity,
+    String? source,
+    int? page,
+    int? pageSize,
+  }) async {
+    _ensureInitialized();
+    if (_config.isDemoMode) {
+      _current = _demoAlerts;
+      _controller.add(_current);
+      return _current;
+    }
+    final params = <String, dynamic>{
+      'from': from?.toIso8601String(),
+      'to': to?.toIso8601String(),
+      'severity': severity,
+      'source': source,
+      'page': page,
+      'pageSize': pageSize,
+    };
+    try {
+      final dtos = await _remote.fetchAlerts(params);
+      await _local.cacheAlerts(dtos);
+      _current = dtos.map((dto) => dto.toDomain()).toList();
+      _controller.add(_current);
+      return _current;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch alerts', error);
+      if (_current.isNotEmpty) {
+        return _current;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Alert> getAlert(String id) async {
+    final existing = _current.firstWhere(
+      (alert) => alert.id == id,
+      orElse: () => Alert(
+        id: id,
+        type: '',
+        severity: AlertSeverity.low,
+        source: AlertSource.system,
+        createdAt: DateTime.now(),
+      ),
+    );
+    if (existing.type.isNotEmpty) {
+      return existing;
+    }
+    final dtos = await _local.loadAlerts();
+    final match = dtos.firstWhere(
+      (dto) => dto.id == id,
+      orElse: () => AlertDto(
+        id: id,
+        type: '',
+        severity: 'low',
+        source: 'system',
+        createdAt: DateTime.now(),
+      ),
+    );
+    if (match.type.isNotEmpty) {
+      return match.toDomain();
+    }
+    if (_config.isDemoMode) {
+      return _demoAlerts.firstWhere((alert) => alert.id == id);
+    }
+    final remote = await _remote.getAlert(id);
+    await _local.upsertAlert(remote);
+    final alert = remote.toDomain();
+    _replaceAlert(alert);
+    return alert;
+  }
+
+  @override
+  Future<Alert> resolveAlert(String id) async {
+    final original = await getAlert(id);
+    final optimistic = Alert(
+      id: original.id,
+      type: original.type,
+      severity: original.severity,
+      source: original.source,
+      createdAt: original.createdAt,
+      resolvedAt: DateTime.now(),
+      assignedTo: original.assignedTo,
+      payload: original.payload,
+    );
+    _replaceAlert(optimistic);
+    await _local.upsertAlert(AlertDto.fromDomain(optimistic));
+
+    if (_config.isDemoMode) {
+      return optimistic;
+    }
+
+    try {
+      final dto = await _remote.resolveAlert(id);
+      await _local.upsertAlert(dto);
+      final resolved = dto.toDomain();
+      _replaceAlert(resolved);
+      return resolved;
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        await _outbox.enqueue(
+          method: 'POST',
+          endpoint: '/alerts/$id/resolve',
+          body: const {},
+        );
+        return optimistic;
+      }
+      await _local.upsertAlert(AlertDto.fromDomain(original));
+      _replaceAlert(original);
+      throw error;
+    }
+  }
+
+  Future<void> addRealtimeAlert(Alert alert) async {
+    _replaceAlert(alert);
+    await _local.upsertAlert(AlertDto.fromDomain(alert));
+  }
+
+  void _replaceAlert(Alert alert) {
+    final index = _current.indexWhere((element) => element.id == alert.id);
+    if (index >= 0) {
+      _current[index] = alert;
+    } else {
+      _current = [..._current, alert];
+    }
+    _controller.add(List<Alert>.unmodifiable(_current));
+  }
+
+  List<Alert> get _demoAlerts => <Alert>[
+        Alert(
+          id: 'a-1',
+          type: 'Temperatura elevada',
+          severity: AlertSeverity.high,
+          source: AlertSource.system,
+          createdAt: DateTime.now().subtract(const Duration(hours: 1)),
+          payload: const {'sensor': 'main'},
+        ),
+        Alert(
+          id: 'a-2',
+          type: 'Movimiento sospechoso',
+          severity: AlertSeverity.medium,
+          source: AlertSource.camera,
+          createdAt: DateTime.now().subtract(const Duration(minutes: 45)),
+        ),
+      ];
+}

--- a/lib/data/alerts/datasources/alerts_local_data_source.dart
+++ b/lib/data/alerts/datasources/alerts_local_data_source.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+
+import 'package:isar/isar.dart';
+
+import '../../../core/database/entities.dart';
+import '../models/alert_dto.dart';
+
+class AlertsLocalDataSource {
+  AlertsLocalDataSource(this._isar);
+
+  final Isar _isar;
+
+  Future<List<AlertDto>> loadAlerts() async {
+    final query = _isar.cachedEntitys.buildQuery<CachedEntity>();
+    final all = await query.findAll();
+    final alerts = all
+        .where((entity) => entity.type == 'alert')
+        .map((entity) => AlertDto.fromJson(
+              jsonDecode(entity.data) as Map<String, dynamic>,
+            ))
+        .toList();
+    return alerts;
+  }
+
+  Future<void> cacheAlerts(List<AlertDto> alerts) async {
+    await _isar.writeTxn(() async {
+      final existing = await _isar.cachedEntitys.buildQuery<CachedEntity>().findAll();
+      for (final entity in existing.where((element) => element.type == 'alert')) {
+        await _isar.cachedEntitys.delete(entity.id);
+      }
+      for (final alert in alerts) {
+        final entity = CachedEntity.create(
+          type: 'alert',
+          entityId: alert.id,
+          data: jsonEncode(alert.toJson()),
+        );
+        await _isar.cachedEntitys.put(entity);
+      }
+    });
+  }
+
+  Future<void> upsertAlert(AlertDto alert) async {
+    await _isar.writeTxn(() async {
+      final entity = CachedEntity.create(
+        type: 'alert',
+        entityId: alert.id,
+        data: jsonEncode(alert.toJson()),
+      );
+      await _isar.cachedEntitys.put(entity);
+    });
+  }
+}

--- a/lib/data/alerts/datasources/alerts_remote_data_source.dart
+++ b/lib/data/alerts/datasources/alerts_remote_data_source.dart
@@ -1,0 +1,32 @@
+import '../../../core/network/http_client.dart';
+import '../models/alert_dto.dart';
+
+class AlertsRemoteDataSource {
+  AlertsRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<List<AlertDto>> fetchAlerts(Map<String, dynamic> params) async {
+    final response = await _client.get<List<dynamic>>(
+      '/alerts',
+      queryParameters: params..removeWhere((key, value) => value == null),
+    );
+    final data = response.data ?? const [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(AlertDto.fromJson)
+        .toList();
+  }
+
+  Future<AlertDto> getAlert(String id) async {
+    final response = await _client.get<Map<String, dynamic>>('/alerts/$id');
+    return AlertDto.fromJson(response.data ?? const {});
+  }
+
+  Future<AlertDto> resolveAlert(String id) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/alerts/$id/resolve',
+    );
+    return AlertDto.fromJson(response.data ?? const {});
+  }
+}

--- a/lib/data/alerts/models/alert_dto.dart
+++ b/lib/data/alerts/models/alert_dto.dart
@@ -1,0 +1,99 @@
+import '../../../domain/alerts/alert.dart';
+
+class AlertDto {
+  AlertDto({
+    required this.id,
+    required this.type,
+    required this.severity,
+    required this.source,
+    required this.createdAt,
+    this.resolvedAt,
+    this.assignedTo,
+    this.payload,
+  });
+
+  final String id;
+  final String type;
+  final String severity;
+  final String source;
+  final DateTime createdAt;
+  final DateTime? resolvedAt;
+  final String? assignedTo;
+  final Map<String, dynamic>? payload;
+
+  factory AlertDto.fromJson(Map<String, dynamic> json) {
+    return AlertDto(
+      id: json['id'].toString(),
+      type: json['type'] as String? ?? '',
+      severity: json['severity'] as String? ?? 'low',
+      source: json['source'] as String? ?? 'system',
+      createdAt: DateTime.tryParse(json['createdAt'] as String? ?? '') ??
+          DateTime.now(),
+      resolvedAt: json['resolvedAt'] != null
+          ? DateTime.tryParse(json['resolvedAt'] as String)
+          : null,
+      assignedTo: json['assignedTo'] as String?,
+      payload: json['payload'] as Map<String, dynamic>?,
+    );
+  }
+
+  factory AlertDto.fromDomain(Alert alert) => AlertDto(
+        id: alert.id,
+        type: alert.type,
+        severity: alert.severity.name,
+        source: alert.source.name,
+        createdAt: alert.createdAt,
+        resolvedAt: alert.resolvedAt,
+        assignedTo: alert.assignedTo,
+        payload: alert.payload,
+      );
+
+  Alert toDomain() => Alert(
+        id: id,
+        type: type,
+        severity: _mapSeverity(severity),
+        source: _mapSource(source),
+        createdAt: createdAt,
+        resolvedAt: resolvedAt,
+        assignedTo: assignedTo,
+        payload: payload,
+      );
+
+  static AlertSeverity _mapSeverity(String raw) {
+    switch (raw.toLowerCase()) {
+      case 'critical':
+        return AlertSeverity.critical;
+      case 'high':
+        return AlertSeverity.high;
+      case 'medium':
+      case 'med':
+        return AlertSeverity.medium;
+      default:
+        return AlertSeverity.low;
+    }
+  }
+
+  static AlertSource _mapSource(String raw) {
+    switch (raw.toLowerCase()) {
+      case 'camera':
+        return AlertSource.camera;
+      case 'fuel':
+        return AlertSource.fuel;
+      case 'tools':
+        return AlertSource.tools;
+      default:
+        return AlertSource.system;
+    }
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'type': type,
+        'severity': severity,
+        'source': source,
+        'createdAt': createdAt.toIso8601String(),
+        'resolvedAt': resolvedAt?.toIso8601String(),
+        'assignedTo': assignedTo,
+        'payload': payload,
+      };
+}

--- a/lib/data/auth/auth_repository_impl.dart
+++ b/lib/data/auth/auth_repository_impl.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+import 'dart:math';
+
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/logging/app_logger.dart';
+import '../../core/network/http_client.dart';
+import '../../core/security/token_storage.dart' as core;
+import '../../domain/auth/entities/app_user.dart';
+import '../../domain/auth/entities/auth_session.dart';
+import '../../domain/auth/repositories/auth_repository.dart';
+import 'datasources/auth_local_data_source.dart';
+import 'datasources/auth_remote_data_source.dart';
+
+class AuthRepositoryImpl implements AuthRepository, AuthTokenManager {
+  AuthRepositoryImpl(
+    this._config,
+    this._remote,
+    this._local,
+    this._logger,
+  );
+
+  final AppConfig _config;
+  final AuthRemoteDataSource _remote;
+  final AuthLocalDataSource _local;
+  final AppLogger _logger;
+
+  AuthSession? _session;
+  core.AuthTokens? _cachedTokens;
+  int _failedAttempts = 0;
+  DateTime? _nextLoginAllowed;
+  Completer<bool>? _refreshCompleter;
+
+  @override
+  Future<AuthSession> login({
+    required String username,
+    required String password,
+  }) async {
+    final now = DateTime.now();
+    if (_nextLoginAllowed != null && now.isBefore(_nextLoginAllowed!)) {
+      final wait = _nextLoginAllowed!.difference(now).inSeconds;
+      throw AppError(
+        AppErrorCode.forbidden,
+        'Demasiados intentos. Esperá ${max(wait, 1)} segundos.',
+      );
+    }
+
+    try {
+      final session = _config.isDemoMode
+          ? _demoLogin(username, password)
+          : await _remoteLogin(username, password);
+      await _persistTokens(session.tokens);
+      _session = session;
+      _failedAttempts = 0;
+      _nextLoginAllowed = null;
+      return session;
+    } on AppError catch (error) {
+      _failedAttempts += 1;
+      final delay = Duration(seconds: pow(2, min(_failedAttempts, 5)).toInt());
+      _nextLoginAllowed = DateTime.now().add(delay);
+      throw error;
+    }
+  }
+
+  AuthSession _demoLogin(String username, String password) {
+    if (username == 'ClaudioC' && password == 'ABCD1234') {
+      final user = AppUser(
+        id: 'demo-1',
+        username: 'ClaudioC',
+        displayName: 'Claudio Custodio',
+        role: UserRole.supervisor,
+      );
+      final tokens = SessionTokens(token: 'demo-token', refreshToken: 'demo-refresh');
+      return AuthSession(user: user, tokens: tokens);
+    }
+    throw const AppError(AppErrorCode.unauthorized, 'Credenciales inválidas');
+  }
+
+  Future<AuthSession> _remoteLogin(String username, String password) async {
+    final dto = await _remote.login(username: username, password: password);
+    final session = dto.toDomain();
+    return session;
+  }
+
+  Future<void> _persistTokens(SessionTokens tokens) async {
+    await _local.saveTokens(tokens);
+    _cachedTokens = core.AuthTokens(
+      accessToken: tokens.token,
+      refreshToken: tokens.refreshToken,
+    );
+  }
+
+  @override
+  Future<AuthSession?> loadCurrentSession() async {
+    if (_session != null) {
+      return _session;
+    }
+    final stored = await _local.readTokens();
+    if (stored == null) {
+      return null;
+    }
+    if (_config.isDemoMode) {
+      final user = AppUser(
+        id: 'demo-1',
+        username: 'ClaudioC',
+        displayName: 'Claudio Custodio',
+        role: UserRole.supervisor,
+      );
+      final session = AuthSession(user: user, tokens: stored);
+      _session = session;
+      _cachedTokens = core.AuthTokens(
+        accessToken: stored.token,
+        refreshToken: stored.refreshToken,
+      );
+      return session;
+    }
+    try {
+      final me = await _remote.fetchMe();
+      final session = AuthSession(
+        user: me.toDomain(),
+        tokens: stored,
+      );
+      _session = session;
+      _cachedTokens = core.AuthTokens(
+        accessToken: stored.token,
+        refreshToken: stored.refreshToken,
+      );
+      return session;
+    } on AppError catch (error) {
+      if (error.code == AppErrorCode.unauthorized) {
+        await logout();
+        return null;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<AppUser> refreshUser() async {
+    try {
+      final dto = await _remote.fetchMe();
+      final user = dto.toDomain();
+      if (_session != null) {
+        _session = AuthSession(user: user, tokens: _session!.tokens);
+      }
+      return user;
+    } on AppError catch (error) {
+      if (error.code == AppErrorCode.unauthorized) {
+        final refreshed = await refreshToken();
+        if (refreshed) {
+          final dto = await _remote.fetchMe();
+          final user = dto.toDomain();
+          if (_session != null) {
+            _session = AuthSession(user: user, tokens: _session!.tokens);
+          }
+          return user;
+        }
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<bool> refreshToken() async {
+    if (_config.isDemoMode) {
+      return true;
+    }
+    if (_refreshCompleter != null) {
+      return _refreshCompleter!.future;
+    }
+    final completer = Completer<bool>();
+    _refreshCompleter = completer;
+    try {
+      final tokens = await _local.readTokens();
+      if (tokens == null || tokens.refreshToken.isEmpty) {
+        await logout();
+        completer.complete(false);
+        return false;
+      }
+      final response = await _remote.refresh(tokens.refreshToken);
+      final newTokens = SessionTokens(
+        token: response.token,
+        refreshToken: response.refreshToken,
+      );
+      await _persistTokens(newTokens);
+      if (_session != null) {
+        _session = AuthSession(user: _session!.user, tokens: newTokens);
+      }
+      completer.complete(true);
+      return true;
+    } on AppError catch (error) {
+      _logger.warn('Refresh token failed', error);
+      await logout();
+      completer.complete(false);
+      return false;
+    } finally {
+      _refreshCompleter = null;
+    }
+  }
+
+  @override
+  Future<void> logout() async {
+    await _local.clear();
+    _cachedTokens = null;
+    _session = null;
+  }
+
+  @override
+  Future<core.AuthTokens?> readTokens() async {
+    if (_cachedTokens != null) {
+      return _cachedTokens;
+    }
+    final stored = await _local.readTokens();
+    if (stored == null) {
+      return null;
+    }
+    _cachedTokens = core.AuthTokens(
+      accessToken: stored.token,
+      refreshToken: stored.refreshToken,
+    );
+    return _cachedTokens;
+  }
+
+  @override
+  void handleUnauthorized() {
+    logout();
+  }
+}

--- a/lib/data/auth/datasources/auth_local_data_source.dart
+++ b/lib/data/auth/datasources/auth_local_data_source.dart
@@ -1,0 +1,28 @@
+import '../../../core/security/token_storage.dart' as core;
+import '../../../core/security/token_storage.dart';
+import '../../../domain/auth/entities/auth_session.dart';
+
+class AuthLocalDataSource {
+  AuthLocalDataSource(this._tokenStorage);
+
+  final TokenStorage _tokenStorage;
+
+  Future<void> saveTokens(SessionTokens tokens) async {
+    await _tokenStorage.save(
+      core.AuthTokens(
+        accessToken: tokens.token,
+        refreshToken: tokens.refreshToken,
+      ),
+    );
+  }
+
+  Future<SessionTokens?> readTokens() async {
+    final stored = await _tokenStorage.read();
+    if (stored == null) {
+      return null;
+    }
+    return SessionTokens(token: stored.accessToken, refreshToken: stored.refreshToken);
+  }
+
+  Future<void> clear() => _tokenStorage.clear();
+}

--- a/lib/data/auth/datasources/auth_remote_data_source.dart
+++ b/lib/data/auth/datasources/auth_remote_data_source.dart
@@ -1,0 +1,44 @@
+import 'package:dio/dio.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../core/network/http_client.dart';
+import '../models/auth_response_dto.dart';
+import '../models/refresh_response_dto.dart';
+import '../models/user_dto.dart';
+
+class AuthRemoteDataSource {
+  AuthRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<AuthResponseDto> login({
+    required String username,
+    required String password,
+  }) async {
+    try {
+      final response = await _client.post<Map<String, dynamic>>(
+        '/auth/login',
+        data: {
+          'username': username,
+          'password': password,
+        },
+      );
+      return AuthResponseDto.fromJson(response.data ?? const {});
+    } on AppError {
+      rethrow;
+    }
+  }
+
+  Future<RefreshResponseDto> refresh(String refreshToken) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/auth/refresh',
+      data: {'refreshToken': refreshToken},
+    );
+    return RefreshResponseDto.fromJson(response.data ?? const {});
+  }
+
+  Future<UserDto> fetchMe() async {
+    final response = await _client.get<Map<String, dynamic>>('/auth/me');
+    return UserDto.fromJson(response.data ?? const {});
+  }
+}

--- a/lib/data/auth/models/auth_response_dto.dart
+++ b/lib/data/auth/models/auth_response_dto.dart
@@ -1,0 +1,27 @@
+import 'user_dto.dart';
+import '../../../domain/auth/entities/auth_session.dart';
+
+class AuthResponseDto {
+  AuthResponseDto({
+    required this.token,
+    required this.refreshToken,
+    required this.user,
+  });
+
+  final String token;
+  final String refreshToken;
+  final UserDto user;
+
+  factory AuthResponseDto.fromJson(Map<String, dynamic> json) {
+    return AuthResponseDto(
+      token: json['token'] as String? ?? '',
+      refreshToken: json['refreshToken'] as String? ?? '',
+      user: UserDto.fromJson(json['user'] as Map<String, dynamic>),
+    );
+  }
+
+  AuthSession toDomain() => AuthSession(
+        user: user.toDomain(),
+        tokens: SessionTokens(token: token, refreshToken: refreshToken),
+      );
+}

--- a/lib/data/auth/models/refresh_response_dto.dart
+++ b/lib/data/auth/models/refresh_response_dto.dart
@@ -1,0 +1,12 @@
+class RefreshResponseDto {
+  RefreshResponseDto({required this.token, required this.refreshToken});
+
+  final String token;
+  final String refreshToken;
+
+  factory RefreshResponseDto.fromJson(Map<String, dynamic> json) =>
+      RefreshResponseDto(
+        token: json['token'] as String? ?? '',
+        refreshToken: json['refreshToken'] as String? ?? '',
+      );
+}

--- a/lib/data/auth/models/user_dto.dart
+++ b/lib/data/auth/models/user_dto.dart
@@ -1,0 +1,51 @@
+import '../../../domain/auth/entities/app_user.dart';
+
+enum _UserRoleDto { admin, supervisor, operario, viewer }
+
+class UserDto {
+  UserDto({
+    required this.id,
+    required this.username,
+    required this.displayName,
+    required this.role,
+  });
+
+  final String id;
+  final String username;
+  final String displayName;
+  final _UserRoleDto role;
+
+  factory UserDto.fromJson(Map<String, dynamic> json) {
+    final role = json['role'] as String? ?? 'viewer';
+    final dtoRole = _UserRoleDto.values.firstWhere(
+      (value) => value.name.toLowerCase() == role.toLowerCase(),
+      orElse: () => _UserRoleDto.viewer,
+    );
+    return UserDto(
+      id: json['id'].toString(),
+      username: json['username'] as String? ?? '',
+      displayName: json['displayName'] as String? ?? '',
+      role: dtoRole,
+    );
+  }
+
+  AppUser toDomain() => AppUser(
+        id: id,
+        username: username,
+        displayName: displayName,
+        role: _mapRole(role),
+      );
+
+  static UserRole _mapRole(_UserRoleDto role) {
+    switch (role) {
+      case _UserRoleDto.admin:
+        return UserRole.admin;
+      case _UserRoleDto.supervisor:
+        return UserRole.supervisor;
+      case _UserRoleDto.operario:
+        return UserRole.operario;
+      case _UserRoleDto.viewer:
+        return UserRole.viewer;
+    }
+  }
+}

--- a/lib/data/cameras/cameras_repository_impl.dart
+++ b/lib/data/cameras/cameras_repository_impl.dart
@@ -1,0 +1,92 @@
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/logging/app_logger.dart';
+import '../../domain/cameras/camera.dart';
+import '../../domain/cameras/cameras_repository.dart';
+import 'datasources/cameras_local_data_source.dart';
+import 'datasources/cameras_remote_data_source.dart';
+import 'models/camera_dto.dart';
+
+class CamerasRepositoryImpl implements CamerasRepository {
+  CamerasRepositoryImpl(
+    this._remote,
+    this._local,
+    this._config,
+    this._logger,
+  );
+
+  final CamerasRemoteDataSource _remote;
+  final CamerasLocalDataSource _local;
+  final AppConfig _config;
+  final AppLogger _logger;
+
+  List<Camera> _cache = <Camera>[];
+
+  @override
+  Future<List<Camera>> fetchCameras() async {
+    if (_config.isDemoMode) {
+      _cache = _demoCameras;
+      return _cache;
+    }
+    try {
+      final dtos = await _remote.fetchCameras();
+      await _local.cacheAll(dtos);
+      _cache = dtos.map((dto) => dto.toDomain()).toList();
+      return _cache;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch cameras', error);
+      if (_cache.isNotEmpty) {
+        return _cache;
+      }
+      final cached = await _local.load();
+      if (cached.isNotEmpty) {
+        _cache = cached.map((dto) => dto.toDomain()).toList();
+        return _cache;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Camera> getCamera(String id) async {
+    if (_cache.isEmpty) {
+      await fetchCameras();
+    }
+    final camera = _cache.firstWhere(
+      (cam) => cam.id == id,
+      orElse: () => Camera(
+        id: id,
+        name: '',
+        location: '',
+        status: CameraStatus.offline,
+      ),
+    );
+    if (camera.name.isNotEmpty) {
+      return camera;
+    }
+    if (_config.isDemoMode) {
+      return _demoCameras.firstWhere((cam) => cam.id == id);
+    }
+    final dto = await _remote.getCamera(id);
+    await _local.cacheOne(dto);
+    final result = dto.toDomain();
+    _cache = [..._cache.where((cam) => cam.id != id), result];
+    return result;
+  }
+
+  List<Camera> get _demoCameras => <Camera>[
+        Camera(
+          id: 'c-1',
+          name: 'Patio Central',
+          location: 'Galpón A',
+          status: CameraStatus.online,
+          streamUrl: 'rtsp://demo',
+        ),
+        Camera(
+          id: 'c-2',
+          name: 'Ingreso',
+          location: 'Portón 1',
+          status: CameraStatus.offline,
+        ),
+      ];
+}

--- a/lib/data/cameras/datasources/cameras_local_data_source.dart
+++ b/lib/data/cameras/datasources/cameras_local_data_source.dart
@@ -1,0 +1,19 @@
+import '../../../core/database/cache_store.dart';
+import '../models/camera_dto.dart';
+
+class CamerasLocalDataSource {
+  CamerasLocalDataSource(this._cache);
+
+  final CacheStore _cache;
+
+  Future<List<CameraDto>> load() async {
+    final data = await _cache.readAll('camera');
+    return data.map(CameraDto.fromJson).toList();
+  }
+
+  Future<void> cacheAll(List<CameraDto> cameras) =>
+      _cache.saveAll('camera', cameras.map((dto) => dto.toJson()).toList());
+
+  Future<void> cacheOne(CameraDto camera) =>
+      _cache.saveOne('camera', camera.id, camera.toJson());
+}

--- a/lib/data/cameras/datasources/cameras_remote_data_source.dart
+++ b/lib/data/cameras/datasources/cameras_remote_data_source.dart
@@ -1,0 +1,22 @@
+import '../../../core/network/http_client.dart';
+import '../models/camera_dto.dart';
+
+class CamerasRemoteDataSource {
+  CamerasRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<List<CameraDto>> fetchCameras() async {
+    final response = await _client.get<List<dynamic>>('/cameras');
+    final data = response.data ?? const [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(CameraDto.fromJson)
+        .toList();
+  }
+
+  Future<CameraDto> getCamera(String id) async {
+    final response = await _client.get<Map<String, dynamic>>('/cameras/$id');
+    return CameraDto.fromJson(response.data ?? const {});
+  }
+}

--- a/lib/data/cameras/models/camera_dto.dart
+++ b/lib/data/cameras/models/camera_dto.dart
@@ -1,0 +1,51 @@
+import '../../../domain/cameras/camera.dart';
+
+class CameraDto {
+  CameraDto({
+    required this.id,
+    required this.name,
+    required this.location,
+    required this.status,
+    this.streamUrl,
+    this.streamHls,
+    this.thumbnailUrl,
+  });
+
+  final String id;
+  final String name;
+  final String location;
+  final String status;
+  final String? streamUrl;
+  final String? streamHls;
+  final String? thumbnailUrl;
+
+  factory CameraDto.fromJson(Map<String, dynamic> json) => CameraDto(
+        id: json['id'].toString(),
+        name: json['name'] as String? ?? '',
+        location: json['location'] as String? ?? '',
+        status: json['status'] as String? ?? 'offline',
+        streamUrl: json['streamUrl'] as String?,
+        streamHls: json['streamHls'] as String?,
+        thumbnailUrl: json['thumbnailUrl'] as String?,
+      );
+
+  Camera toDomain() => Camera(
+        id: id,
+        name: name,
+        location: location,
+        status: status == 'online' ? CameraStatus.online : CameraStatus.offline,
+        streamUrl: streamUrl,
+        streamHls: streamHls,
+        thumbnailUrl: thumbnailUrl,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'location': location,
+        'status': status,
+        'streamUrl': streamUrl,
+        'streamHls': streamHls,
+        'thumbnailUrl': thumbnailUrl,
+      };
+}

--- a/lib/data/fuel/datasources/fuel_local_data_source.dart
+++ b/lib/data/fuel/datasources/fuel_local_data_source.dart
@@ -1,0 +1,36 @@
+import '../../../core/database/cache_store.dart';
+import '../models/fuel_event_dto.dart';
+import '../models/fuel_kpis_dto.dart';
+
+class FuelLocalDataSource {
+  FuelLocalDataSource(this._cacheStore);
+
+  final CacheStore _cacheStore;
+
+  static const _eventsType = 'fuel_event';
+  static const _kpisType = 'fuel_kpis';
+
+  Future<void> cacheEvents(List<FuelEventDto> events) async {
+    await _cacheStore.saveAll(
+      _eventsType,
+      events.map((dto) => dto.toJson()).toList(),
+    );
+  }
+
+  Future<List<FuelEventDto>> loadEvents() async {
+    final cached = await _cacheStore.readAll(_eventsType);
+    return cached.map(FuelEventDto.fromJson).toList();
+  }
+
+  Future<void> cacheKpis(FuelKpisDto dto) async {
+    await _cacheStore.saveOne(_kpisType, dto.range, dto.toJson());
+  }
+
+  Future<FuelKpisDto?> loadKpis(String range) async {
+    final cached = await _cacheStore.readOne(_kpisType, range);
+    if (cached == null) {
+      return null;
+    }
+    return FuelKpisDto.fromJson(cached);
+  }
+}

--- a/lib/data/fuel/datasources/fuel_remote_data_source.dart
+++ b/lib/data/fuel/datasources/fuel_remote_data_source.dart
@@ -1,0 +1,37 @@
+import '../../../core/network/http_client.dart';
+import '../models/fuel_event_dto.dart';
+import '../models/fuel_kpis_dto.dart';
+
+class FuelRemoteDataSource {
+  FuelRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<List<FuelEventDto>> fetchEvents(Map<String, dynamic> params) async {
+    final response = await _client.get<List<dynamic>>(
+      '/fuel/events',
+      queryParameters: params,
+    );
+    final data = response.data ?? const [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(FuelEventDto.fromJson)
+        .toList();
+  }
+
+  Future<FuelEventDto> createEvent(Map<String, dynamic> body) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/fuel/events',
+      data: body,
+    );
+    return FuelEventDto.fromJson(response.data ?? const {});
+  }
+
+  Future<FuelKpisDto> fetchKpis(String range) async {
+    final response = await _client.get<Map<String, dynamic>>(
+      '/fuel/kpis',
+      queryParameters: {'range': range},
+    );
+    return FuelKpisDto.fromJson(response.data ?? const {});
+  }
+}

--- a/lib/data/fuel/fuel_repository_impl.dart
+++ b/lib/data/fuel/fuel_repository_impl.dart
@@ -1,0 +1,177 @@
+import 'package:uuid/uuid.dart';
+
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/logging/app_logger.dart';
+import '../../core/offline/outbox_service.dart';
+import '../../domain/fuel/fuel_event.dart';
+import '../../domain/fuel/fuel_repository.dart';
+import 'datasources/fuel_local_data_source.dart';
+import 'datasources/fuel_remote_data_source.dart';
+import 'models/fuel_event_dto.dart';
+import 'models/fuel_kpis_dto.dart';
+
+class FuelRepositoryImpl implements FuelRepository {
+  FuelRepositoryImpl(
+    this._remote,
+    this._local,
+    this._config,
+    this._outbox,
+    this._logger,
+  );
+
+  final FuelRemoteDataSource _remote;
+  final FuelLocalDataSource _local;
+  final AppConfig _config;
+  final OutboxService _outbox;
+  final AppLogger _logger;
+
+  final _uuid = const Uuid();
+
+  List<FuelEvent> _eventsCache = <FuelEvent>[];
+  FuelKpis? _kpisCache;
+
+  @override
+  Future<List<FuelEvent>> fetchEvents({
+    DateTime? from,
+    DateTime? to,
+    String? vehicle,
+    String? operatorId,
+    int? page,
+  }) async {
+    final cachedDtos = await _local.loadEvents();
+    if (cachedDtos.isNotEmpty && _eventsCache.isEmpty) {
+      _eventsCache = cachedDtos.map((dto) => dto.toDomain()).toList();
+    }
+
+    if (_config.isDemoMode) {
+      _eventsCache = _demoEvents;
+      return _eventsCache;
+    }
+
+    final params = <String, dynamic>{
+      'from': from?.toIso8601String(),
+      'to': to?.toIso8601String(),
+      'vehicle': vehicle,
+      'operator': operatorId,
+      'page': page,
+    }..removeWhere((key, value) => value == null || value == '');
+
+    try {
+      final dtos = await _remote.fetchEvents(params);
+      await _local.cacheEvents(dtos);
+      _eventsCache = dtos.map((dto) => dto.toDomain()).toList();
+      return _eventsCache;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch fuel events', error);
+      if (_eventsCache.isNotEmpty && error.code.isNetworkError) {
+        return _eventsCache;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<FuelEvent> createEvent(FuelEvent event) async {
+    final baseEvent = event.id.isEmpty
+        ? FuelEvent(
+            id: _uuid.v4(),
+            vehicleId: event.vehicleId,
+            operatorId: event.operatorId,
+            liters: event.liters,
+            timestamp: event.timestamp,
+            source: event.source,
+          )
+        : event;
+
+    if (_config.isDemoMode) {
+      _eventsCache = [..._eventsCache, baseEvent];
+      await _local.cacheEvents(
+        _eventsCache.map(FuelEventDto.fromDomain).toList(),
+      );
+      return baseEvent;
+    }
+
+    final dto = FuelEventDto.fromDomain(baseEvent);
+    try {
+      final created = await _remote.createEvent(dto.toJson());
+      final domain = created.toDomain();
+      _eventsCache = [..._eventsCache, domain];
+      await _local.cacheEvents(
+        _eventsCache.map(FuelEventDto.fromDomain).toList(),
+      );
+      return domain;
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        await _local.cacheEvents(
+          [..._eventsCache, baseEvent]
+              .map(FuelEventDto.fromDomain)
+              .toList(),
+        );
+        _eventsCache = [..._eventsCache, baseEvent];
+        await _outbox.enqueue(
+          method: 'POST',
+          endpoint: '/fuel/events',
+          body: dto.toJson(),
+          reference: baseEvent.id,
+        );
+        return baseEvent;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<FuelKpis> fetchKpis({required String range}) async {
+    if (_config.isDemoMode) {
+      final demo = _demoKpis(range);
+      _kpisCache = demo;
+      return demo;
+    }
+    if (_kpisCache != null && _kpisCache!.range == range) {
+      return _kpisCache!;
+    }
+    final cached = await _local.loadKpis(range);
+    if (cached != null) {
+      final domain = cached.toDomain();
+      _kpisCache = domain;
+      return domain;
+    }
+    try {
+      final dto = await _remote.fetchKpis(range);
+      await _local.cacheKpis(dto);
+      final domain = dto.toDomain();
+      _kpisCache = domain;
+      return domain;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch fuel KPIs', error);
+      if (_kpisCache != null && error.code.isNetworkError) {
+        return _kpisCache!;
+      }
+      rethrow;
+    }
+  }
+
+  List<FuelEvent> get _demoEvents => <FuelEvent>[
+        FuelEvent(
+          id: _uuid.v4(),
+          vehicleId: 'truck-1',
+          operatorId: 'op-1',
+          liters: 120,
+          timestamp: DateTime.now().subtract(const Duration(hours: 3)),
+          source: FuelSource.esp32,
+        ),
+        FuelEvent(
+          id: _uuid.v4(),
+          vehicleId: 'truck-2',
+          operatorId: 'op-2',
+          liters: 80,
+          timestamp: DateTime.now().subtract(const Duration(days: 1)),
+          source: FuelSource.manual,
+        ),
+      ];
+
+  FuelKpis _demoKpis(String range) {
+    return FuelKpis(range: range, totalLiters: 340);
+  }
+}

--- a/lib/data/fuel/models/fuel_event_dto.dart
+++ b/lib/data/fuel/models/fuel_event_dto.dart
@@ -1,0 +1,65 @@
+import '../../../domain/fuel/fuel_event.dart';
+
+class FuelEventDto {
+  FuelEventDto({
+    required this.id,
+    required this.vehicleId,
+    required this.operatorId,
+    required this.liters,
+    required this.timestamp,
+    required this.source,
+  });
+
+  final String id;
+  final String vehicleId;
+  final String operatorId;
+  final double liters;
+  final DateTime timestamp;
+  final String source;
+
+  factory FuelEventDto.fromJson(Map<String, dynamic> json) {
+    return FuelEventDto(
+      id: json['id'].toString(),
+      vehicleId: json['vehicleId'].toString(),
+      operatorId: json['operatorId'].toString(),
+      liters: (json['liters'] as num?)?.toDouble() ?? 0,
+      timestamp: DateTime.tryParse(json['timestamp'] as String? ?? '') ??
+          DateTime.now(),
+      source: (json['source'] as String? ?? 'manual').toLowerCase(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'vehicleId': vehicleId,
+        'operatorId': operatorId,
+        'liters': liters,
+        'timestamp': timestamp.toIso8601String(),
+        'source': source,
+      };
+
+  FuelEvent toDomain() {
+    return FuelEvent(
+      id: id,
+      vehicleId: vehicleId,
+      operatorId: operatorId,
+      liters: liters,
+      timestamp: timestamp,
+      source: FuelSource.values.firstWhere(
+        (value) => value.name == source,
+        orElse: () => FuelSource.manual,
+      ),
+    );
+  }
+
+  static FuelEventDto fromDomain(FuelEvent event) {
+    return FuelEventDto(
+      id: event.id,
+      vehicleId: event.vehicleId,
+      operatorId: event.operatorId,
+      liters: event.liters,
+      timestamp: event.timestamp,
+      source: event.source.name,
+    );
+  }
+}

--- a/lib/data/fuel/models/fuel_kpis_dto.dart
+++ b/lib/data/fuel/models/fuel_kpis_dto.dart
@@ -1,0 +1,25 @@
+import '../../../domain/fuel/fuel_event.dart';
+
+class FuelKpisDto {
+  FuelKpisDto({required this.range, required this.totalLiters});
+
+  final String range;
+  final double totalLiters;
+
+  factory FuelKpisDto.fromJson(Map<String, dynamic> json) {
+    return FuelKpisDto(
+      range: (json['range'] as String? ?? 'week').toLowerCase(),
+      totalLiters: (json['totalLiters'] as num?)?.toDouble() ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'range': range,
+        'totalLiters': totalLiters,
+      };
+
+  FuelKpis toDomain() => FuelKpis(range: range, totalLiters: totalLiters);
+
+  static FuelKpisDto fromDomain(FuelKpis kpis) =>
+      FuelKpisDto(range: kpis.range, totalLiters: kpis.totalLiters);
+}

--- a/lib/data/operators/datasources/operators_local_data_source.dart
+++ b/lib/data/operators/datasources/operators_local_data_source.dart
@@ -1,0 +1,38 @@
+import '../../../core/database/cache_store.dart';
+import '../models/operator_dto.dart';
+
+class OperatorsLocalDataSource {
+  OperatorsLocalDataSource(this._cacheStore);
+
+  final CacheStore _cacheStore;
+
+  static const _operatorsType = 'operators';
+
+  Future<void> cacheOperators(List<OperatorDto> operators) async {
+    await _cacheStore.saveAll(
+      _operatorsType,
+      operators.map((dto) => dto.toJson()).toList(),
+    );
+  }
+
+  Future<void> upsertOperator(OperatorDto operator) async {
+    await _cacheStore.saveOne(
+      _operatorsType,
+      operator.id,
+      operator.toJson(),
+    );
+  }
+
+  Future<List<OperatorDto>> loadOperators() async {
+    final cached = await _cacheStore.readAll(_operatorsType);
+    return cached.map(OperatorDto.fromJson).toList();
+  }
+
+  Future<OperatorDto?> loadOperator(String id) async {
+    final cached = await _cacheStore.readOne(_operatorsType, id);
+    if (cached == null) {
+      return null;
+    }
+    return OperatorDto.fromJson(cached);
+  }
+}

--- a/lib/data/operators/datasources/operators_remote_data_source.dart
+++ b/lib/data/operators/datasources/operators_remote_data_source.dart
@@ -1,0 +1,41 @@
+import '../../../core/network/http_client.dart';
+import '../models/operator_dto.dart';
+
+class OperatorsRemoteDataSource {
+  OperatorsRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<List<OperatorDto>> fetchOperators(Map<String, dynamic> params) async {
+    final response = await _client.get<List<dynamic>>(
+      '/operators',
+      queryParameters: params,
+    );
+    final data = response.data ?? const [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(OperatorDto.fromJson)
+        .toList();
+  }
+
+  Future<OperatorDto> getOperator(String id) async {
+    final response = await _client.get<Map<String, dynamic>>('/operators/$id');
+    return OperatorDto.fromJson(response.data ?? const {});
+  }
+
+  Future<OperatorDto> createOperator(Map<String, dynamic> body) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/operators',
+      data: body,
+    );
+    return OperatorDto.fromJson(response.data ?? const {});
+  }
+
+  Future<OperatorDto> updateOperator(String id, Map<String, dynamic> body) async {
+    final response = await _client.put<Map<String, dynamic>>(
+      '/operators/$id',
+      data: body,
+    );
+    return OperatorDto.fromJson(response.data ?? const {});
+  }
+}

--- a/lib/data/operators/models/operator_dto.dart
+++ b/lib/data/operators/models/operator_dto.dart
@@ -1,0 +1,69 @@
+import '../../../domain/operators/operator.dart';
+
+class OperatorDto {
+  OperatorDto({
+    required this.id,
+    required this.name,
+    required this.role,
+    required this.area,
+    required this.status,
+    this.lastSeenAt,
+  });
+
+  final String id;
+  final String name;
+  final String role;
+  final String area;
+  final String status;
+  final DateTime? lastSeenAt;
+
+  factory OperatorDto.fromJson(Map<String, dynamic> json) {
+    return OperatorDto(
+      id: json['id'].toString(),
+      name: json['name'] as String? ?? '',
+      role: (json['role'] as String? ?? 'operario').toLowerCase(),
+      area: json['area'] as String? ?? '',
+      status: (json['status'] as String? ?? 'active').toLowerCase(),
+      lastSeenAt: json['lastSeenAt'] != null
+          ? DateTime.tryParse(json['lastSeenAt'] as String)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'role': role,
+        'area': area,
+        'status': status,
+        if (lastSeenAt != null) 'lastSeenAt': lastSeenAt!.toIso8601String(),
+      };
+
+  Operator toDomain() {
+    return Operator(
+      id: id,
+      name: name,
+      role: OperatorRole.values.firstWhere(
+        (value) => value.name == role,
+        orElse: () => OperatorRole.operario,
+      ),
+      area: area,
+      status: OperatorStatus.values.firstWhere(
+        (value) => value.name == status,
+        orElse: () => OperatorStatus.active,
+      ),
+      lastSeenAt: lastSeenAt,
+    );
+  }
+
+  static OperatorDto fromDomain(Operator operator) {
+    return OperatorDto(
+      id: operator.id,
+      name: operator.name,
+      role: operator.role.name,
+      area: operator.area,
+      status: operator.status.name,
+      lastSeenAt: operator.lastSeenAt,
+    );
+  }
+}

--- a/lib/data/operators/operators_repository_impl.dart
+++ b/lib/data/operators/operators_repository_impl.dart
@@ -1,0 +1,213 @@
+import 'package:uuid/uuid.dart';
+
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/logging/app_logger.dart';
+import '../../core/offline/outbox_service.dart';
+import '../../domain/operators/operator.dart';
+import '../../domain/operators/operators_repository.dart';
+import 'datasources/operators_local_data_source.dart';
+import 'datasources/operators_remote_data_source.dart';
+import 'models/operator_dto.dart';
+
+class OperatorsRepositoryImpl implements OperatorsRepository {
+  OperatorsRepositoryImpl(
+    this._remote,
+    this._local,
+    this._config,
+    this._outbox,
+    this._logger,
+  );
+
+  final OperatorsRemoteDataSource _remote;
+  final OperatorsLocalDataSource _local;
+  final AppConfig _config;
+  final OutboxService _outbox;
+  final AppLogger _logger;
+  final _uuid = const Uuid();
+
+  List<Operator> _cached = <Operator>[];
+
+  @override
+  Future<List<Operator>> fetchOperators({String? query, String? status}) async {
+    final cached = await _local.loadOperators();
+    if (_cached.isEmpty && cached.isNotEmpty) {
+      _cached = cached.map((dto) => dto.toDomain()).toList();
+    }
+
+    if (_config.isDemoMode) {
+      _cached = _demoOperators;
+      return _cached;
+    }
+
+    final params = <String, dynamic>{
+      'q': query,
+      'status': status,
+    }..removeWhere((key, value) => value == null || (value is String && value.isEmpty));
+
+    try {
+      final dtos = await _remote.fetchOperators(params);
+      await _local.cacheOperators(dtos);
+      _cached = dtos.map((dto) => dto.toDomain()).toList();
+      return _cached;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch operators', error);
+      if (_cached.isNotEmpty && error.code.isNetworkError) {
+        return _cached;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Operator> getOperator(String id) async {
+    final existing = _cached.firstWhere(
+      (operator) => operator.id == id,
+      orElse: () => Operator(
+        id: '',
+        name: '',
+        role: OperatorRole.operario,
+        area: '',
+        status: OperatorStatus.active,
+      ),
+    );
+    if (existing.id.isNotEmpty) {
+      return existing;
+    }
+
+    if (_config.isDemoMode) {
+      return _demoOperators.firstWhere((operator) => operator.id == id,
+          orElse: () => _demoOperators.first);
+    }
+
+    final cached = await _local.loadOperator(id);
+    if (cached != null) {
+      return cached.toDomain();
+    }
+    final dto = await _remote.getOperator(id);
+    await _local.upsertOperator(dto);
+    final domain = dto.toDomain();
+    _cached = [..._cached.where((op) => op.id != id), domain];
+    return domain;
+  }
+
+  @override
+  Future<Operator> createOperator(Operator operator) async {
+    final withId = operator.id.isEmpty
+        ? Operator(
+            id: _uuid.v4(),
+            name: operator.name,
+            role: operator.role,
+            area: operator.area,
+            status: operator.status,
+            lastSeenAt: operator.lastSeenAt,
+          )
+        : operator;
+
+    if (_config.isDemoMode) {
+      _cached = [..._cached, withId];
+      await _local.cacheOperators(
+        _cached.map(OperatorDto.fromDomain).toList(),
+      );
+      return withId;
+    }
+
+    final dto = OperatorDto.fromDomain(withId);
+    try {
+      final created = await _remote.createOperator(dto.toJson());
+      await _local.upsertOperator(created);
+      final domain = created.toDomain();
+      _cached = [..._cached, domain];
+      return domain;
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        _cached = [..._cached, withId];
+        await _local.cacheOperators(
+          _cached.map(OperatorDto.fromDomain).toList(),
+        );
+        await _outbox.enqueue(
+          method: 'POST',
+          endpoint: '/operators',
+          body: dto.toJson(),
+          reference: withId.id,
+        );
+        return withId;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Operator> updateOperator(String id, Map<String, dynamic> updates) async {
+    if (_config.isDemoMode) {
+      _cached = _cached
+          .map((operator) => operator.id == id
+              ? Operator(
+                  id: operator.id,
+                  name: updates['name'] as String? ?? operator.name,
+                  role: updates['role'] != null
+                      ? OperatorRole.values.firstWhere(
+                          (value) => value.name ==
+                              (updates['role'] as String).toLowerCase(),
+                          orElse: () => operator.role,
+                        )
+                      : operator.role,
+                  area: updates['area'] as String? ?? operator.area,
+                  status: updates['status'] != null
+                      ? OperatorStatus.values.firstWhere(
+                          (value) => value.name ==
+                              (updates['status'] as String).toLowerCase(),
+                          orElse: () => operator.status,
+                        )
+                      : operator.status,
+                  lastSeenAt: operator.lastSeenAt,
+                )
+              : operator)
+          .toList();
+      await _local.cacheOperators(
+        _cached.map(OperatorDto.fromDomain).toList(),
+      );
+      return _cached.firstWhere((operator) => operator.id == id);
+    }
+
+    try {
+      final dto = await _remote.updateOperator(id, updates);
+      await _local.upsertOperator(dto);
+      final domain = dto.toDomain();
+      _cached = _cached
+          .map((operator) => operator.id == id ? domain : operator)
+          .toList();
+      return domain;
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        await _outbox.enqueue(
+          method: 'PUT',
+          endpoint: '/operators/$id',
+          body: updates,
+          reference: id,
+        );
+        return _cached.firstWhere((operator) => operator.id == id);
+      }
+      rethrow;
+    }
+  }
+
+  List<Operator> get _demoOperators => <Operator>[
+        Operator(
+          id: 'op-1',
+          name: 'Claudio Custodio',
+          role: OperatorRole.supervisor,
+          area: 'Seguridad',
+          status: OperatorStatus.active,
+          lastSeenAt: DateTime.now().subtract(const Duration(minutes: 5)),
+        ),
+        Operator(
+          id: 'op-2',
+          name: 'Laura Martínez',
+          role: OperatorRole.operario,
+          area: 'Mantenimiento',
+          status: OperatorStatus.active,
+          lastSeenAt: DateTime.now().subtract(const Duration(hours: 2)),
+        ),
+      ];
+}

--- a/lib/data/projects/datasources/projects_local_data_source.dart
+++ b/lib/data/projects/datasources/projects_local_data_source.dart
@@ -1,0 +1,34 @@
+import '../../../core/database/cache_store.dart';
+import '../models/project_dto.dart';
+
+class ProjectsLocalDataSource {
+  ProjectsLocalDataSource(this._cacheStore);
+
+  final CacheStore _cacheStore;
+
+  static const _projectsType = 'projects';
+
+  Future<void> cacheProjects(List<ProjectDto> projects) async {
+    await _cacheStore.saveAll(
+      _projectsType,
+      projects.map((dto) => dto.toJson()).toList(),
+    );
+  }
+
+  Future<void> upsertProject(ProjectDto project) async {
+    await _cacheStore.saveOne(_projectsType, project.id, project.toJson());
+  }
+
+  Future<List<ProjectDto>> loadProjects() async {
+    final cached = await _cacheStore.readAll(_projectsType);
+    return cached.map(ProjectDto.fromJson).toList();
+  }
+
+  Future<ProjectDto?> loadProject(String id) async {
+    final cached = await _cacheStore.readOne(_projectsType, id);
+    if (cached == null) {
+      return null;
+    }
+    return ProjectDto.fromJson(cached);
+  }
+}

--- a/lib/data/projects/datasources/projects_remote_data_source.dart
+++ b/lib/data/projects/datasources/projects_remote_data_source.dart
@@ -1,0 +1,41 @@
+import '../../../core/network/http_client.dart';
+import '../models/project_dto.dart';
+
+class ProjectsRemoteDataSource {
+  ProjectsRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<List<ProjectDto>> fetchProjects(Map<String, dynamic> params) async {
+    final response = await _client.get<List<dynamic>>(
+      '/projects',
+      queryParameters: params,
+    );
+    final data = response.data ?? const [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(ProjectDto.fromJson)
+        .toList();
+  }
+
+  Future<ProjectDto> getProject(String id) async {
+    final response = await _client.get<Map<String, dynamic>>('/projects/$id');
+    return ProjectDto.fromJson(response.data ?? const {});
+  }
+
+  Future<ProjectDto> createProject(Map<String, dynamic> body) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/projects',
+      data: body,
+    );
+    return ProjectDto.fromJson(response.data ?? const {});
+  }
+
+  Future<ProjectDto> updateProject(String id, Map<String, dynamic> body) async {
+    final response = await _client.patch<Map<String, dynamic>>(
+      '/projects/$id',
+      data: body,
+    );
+    return ProjectDto.fromJson(response.data ?? const {});
+  }
+}

--- a/lib/data/projects/models/project_dto.dart
+++ b/lib/data/projects/models/project_dto.dart
@@ -1,0 +1,78 @@
+import '../../../domain/projects/project.dart';
+
+class ProjectDto {
+  ProjectDto({
+    required this.id,
+    required this.name,
+    required this.status,
+    required this.progressPct,
+    required this.ownerId,
+    required this.startAt,
+    this.endAt,
+    this.budget,
+  });
+
+  final String id;
+  final String name;
+  final String status;
+  final double progressPct;
+  final String ownerId;
+  final DateTime startAt;
+  final DateTime? endAt;
+  final double? budget;
+
+  factory ProjectDto.fromJson(Map<String, dynamic> json) {
+    return ProjectDto(
+      id: json['id'].toString(),
+      name: json['name'] as String? ?? '',
+      status: (json['status'] as String? ?? 'planned').toLowerCase(),
+      progressPct: (json['progressPct'] as num?)?.toDouble() ?? 0,
+      ownerId: json['ownerId'].toString(),
+      startAt: DateTime.tryParse(json['startAt'] as String? ?? '') ?? DateTime.now(),
+      endAt: json['endAt'] != null
+          ? DateTime.tryParse(json['endAt'] as String)
+          : null,
+      budget: (json['budget'] as num?)?.toDouble(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'status': status,
+        'progressPct': progressPct,
+        'ownerId': ownerId,
+        'startAt': startAt.toIso8601String(),
+        if (endAt != null) 'endAt': endAt!.toIso8601String(),
+        if (budget != null) 'budget': budget,
+      };
+
+  Project toDomain() {
+    return Project(
+      id: id,
+      name: name,
+      status: ProjectStatus.values.firstWhere(
+        (value) => value.name == status,
+        orElse: () => ProjectStatus.planned,
+      ),
+      progressPct: progressPct,
+      ownerId: ownerId,
+      startAt: startAt,
+      endAt: endAt,
+      budget: budget,
+    );
+  }
+
+  static ProjectDto fromDomain(Project project) {
+    return ProjectDto(
+      id: project.id,
+      name: project.name,
+      status: project.status.name,
+      progressPct: project.progressPct,
+      ownerId: project.ownerId,
+      startAt: project.startAt,
+      endAt: project.endAt,
+      budget: project.budget,
+    );
+  }
+}

--- a/lib/data/projects/projects_repository_impl.dart
+++ b/lib/data/projects/projects_repository_impl.dart
@@ -1,0 +1,218 @@
+import 'package:uuid/uuid.dart';
+
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/logging/app_logger.dart';
+import '../../core/offline/outbox_service.dart';
+import '../../domain/projects/project.dart';
+import '../../domain/projects/projects_repository.dart';
+import 'datasources/projects_local_data_source.dart';
+import 'datasources/projects_remote_data_source.dart';
+import 'models/project_dto.dart';
+
+class ProjectsRepositoryImpl implements ProjectsRepository {
+  ProjectsRepositoryImpl(
+    this._remote,
+    this._local,
+    this._config,
+    this._outbox,
+    this._logger,
+  );
+
+  final ProjectsRemoteDataSource _remote;
+  final ProjectsLocalDataSource _local;
+  final AppConfig _config;
+  final OutboxService _outbox;
+  final AppLogger _logger;
+  final _uuid = const Uuid();
+
+  List<Project> _cached = <Project>[];
+
+  @override
+  Future<List<Project>> fetchProjects({String? query, String? status}) async {
+    final cached = await _local.loadProjects();
+    if (_cached.isEmpty && cached.isNotEmpty) {
+      _cached = cached.map((dto) => dto.toDomain()).toList();
+    }
+
+    if (_config.isDemoMode) {
+      _cached = _demoProjects;
+      return _cached;
+    }
+
+    final params = <String, dynamic>{
+      'q': query,
+      'status': status,
+    }..removeWhere((key, value) => value == null || (value is String && value.isEmpty));
+
+    try {
+      final dtos = await _remote.fetchProjects(params);
+      await _local.cacheProjects(dtos);
+      _cached = dtos.map((dto) => dto.toDomain()).toList();
+      return _cached;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch projects', error);
+      if (_cached.isNotEmpty && error.code.isNetworkError) {
+        return _cached;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Project> getProject(String id) async {
+    final existing = _cached.firstWhere(
+      (project) => project.id == id,
+      orElse: () => Project(
+        id: '',
+        name: '',
+        status: ProjectStatus.planned,
+        progressPct: 0,
+        ownerId: '',
+        startAt: DateTime.now(),
+      ),
+    );
+    if (existing.id.isNotEmpty) {
+      return existing;
+    }
+
+    if (_config.isDemoMode) {
+      return _demoProjects.firstWhere((project) => project.id == id,
+          orElse: () => _demoProjects.first);
+    }
+
+    final cached = await _local.loadProject(id);
+    if (cached != null) {
+      return cached.toDomain();
+    }
+    final dto = await _remote.getProject(id);
+    await _local.upsertProject(dto);
+    final domain = dto.toDomain();
+    _cached = [..._cached.where((project) => project.id != id), domain];
+    return domain;
+  }
+
+  @override
+  Future<Project> createProject(Project project) async {
+    final withId = project.id.isEmpty
+        ? Project(
+            id: _uuid.v4(),
+            name: project.name,
+            status: project.status,
+            progressPct: project.progressPct,
+            ownerId: project.ownerId,
+            startAt: project.startAt,
+            endAt: project.endAt,
+            budget: project.budget,
+          )
+        : project;
+
+    if (_config.isDemoMode) {
+      _cached = [..._cached, withId];
+      await _local.cacheProjects(
+        _cached.map(ProjectDto.fromDomain).toList(),
+      );
+      return withId;
+    }
+
+    final dto = ProjectDto.fromDomain(withId);
+    try {
+      final created = await _remote.createProject(dto.toJson());
+      await _local.upsertProject(created);
+      final domain = created.toDomain();
+      _cached = [..._cached, domain];
+      return domain;
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        _cached = [..._cached, withId];
+        await _local.cacheProjects(
+          _cached.map(ProjectDto.fromDomain).toList(),
+        );
+        await _outbox.enqueue(
+          method: 'POST',
+          endpoint: '/projects',
+          body: dto.toJson(),
+          reference: withId.id,
+        );
+        return withId;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Project> updateProject(String id, Map<String, dynamic> updates) async {
+    if (_config.isDemoMode) {
+      _cached = _cached
+          .map(
+            (project) => project.id == id
+                ? Project(
+                    id: project.id,
+                    name: updates['name'] as String? ?? project.name,
+                    status: updates['status'] != null
+                        ? ProjectStatus.values.firstWhere(
+                            (value) => value.name ==
+                                (updates['status'] as String).toLowerCase(),
+                            orElse: () => project.status,
+                          )
+                        : project.status,
+                    progressPct: (updates['progressPct'] as num?)?.toDouble() ??
+                        project.progressPct,
+                    ownerId: updates['ownerId'] as String? ?? project.ownerId,
+                    startAt: project.startAt,
+                    endAt: project.endAt,
+                    budget: (updates['budget'] as num?)?.toDouble() ??
+                        project.budget,
+                  )
+                : project,
+          )
+          .toList();
+      await _local.cacheProjects(
+        _cached.map(ProjectDto.fromDomain).toList(),
+      );
+      return _cached.firstWhere((project) => project.id == id);
+    }
+
+    try {
+      final dto = await _remote.updateProject(id, updates);
+      await _local.upsertProject(dto);
+      final domain = dto.toDomain();
+      _cached = _cached
+          .map((project) => project.id == id ? domain : project)
+          .toList();
+      return domain;
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        await _outbox.enqueue(
+          method: 'PATCH',
+          endpoint: '/projects/$id',
+          body: updates,
+          reference: id,
+        );
+        return _cached.firstWhere((project) => project.id == id);
+      }
+      rethrow;
+    }
+  }
+
+  List<Project> get _demoProjects => <Project>[
+        Project(
+          id: 'proj-1',
+          name: 'Instalación sensores',
+          status: ProjectStatus.active,
+          progressPct: 65,
+          ownerId: 'op-1',
+          startAt: DateTime.now().subtract(const Duration(days: 30)),
+          endAt: DateTime.now().add(const Duration(days: 10)),
+          budget: 120000,
+        ),
+        Project(
+          id: 'proj-2',
+          name: 'Renovación cámaras',
+          status: ProjectStatus.planned,
+          progressPct: 10,
+          ownerId: 'op-2',
+          startAt: DateTime.now().add(const Duration(days: 7)),
+        ),
+      ];
+}

--- a/lib/data/reports/reports_remote_data_source.dart
+++ b/lib/data/reports/reports_remote_data_source.dart
@@ -1,0 +1,36 @@
+import 'package:dio/dio.dart';
+
+import '../../core/network/http_client.dart';
+
+class ReportsRemoteDataSource {
+  ReportsRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<List<int>> downloadAlerts(Map<String, dynamic> params) async {
+    final response = await _client.get<List<int>>(
+      '/reports/alerts',
+      queryParameters: params,
+      options: Options(responseType: ResponseType.bytes),
+    );
+    return response.data ?? const <int>[];
+  }
+
+  Future<List<int>> downloadFuel(Map<String, dynamic> params) async {
+    final response = await _client.get<List<int>>(
+      '/reports/fuel',
+      queryParameters: params,
+      options: Options(responseType: ResponseType.bytes),
+    );
+    return response.data ?? const <int>[];
+  }
+
+  Future<List<int>> downloadTools(Map<String, dynamic> params) async {
+    final response = await _client.get<List<int>>(
+      '/reports/tools',
+      queryParameters: params,
+      options: Options(responseType: ResponseType.bytes),
+    );
+    return response.data ?? const <int>[];
+  }
+}

--- a/lib/data/reports/reports_repository_impl.dart
+++ b/lib/data/reports/reports_repository_impl.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/files/file_saver.dart';
+import '../../core/logging/app_logger.dart';
+import '../../domain/reports/reports_repository.dart';
+import 'reports_remote_data_source.dart';
+
+class ReportsRepositoryImpl implements ReportsRepository {
+  ReportsRepositoryImpl(
+    this._remote,
+    this._config,
+    this._logger,
+    FileSaver? saver,
+  ) : _fileSaver = saver ?? createFileSaver();
+
+  final ReportsRemoteDataSource _remote;
+  final AppConfig _config;
+  final AppLogger _logger;
+  final FileSaver _fileSaver;
+
+  @override
+  Future<String> downloadAlertsReport({required DateTime from, required DateTime to}) {
+    return _download(
+      filename: 'alerts-${from.toIso8601String()}-${to.toIso8601String()}.csv',
+      loader: () => _remote.downloadAlerts({
+        'from': from.toIso8601String(),
+        'to': to.toIso8601String(),
+      }),
+      demoContent: _demoAlertsCsv(from, to),
+    );
+  }
+
+  @override
+  Future<String> downloadFuelReport({required DateTime from, required DateTime to}) {
+    return _download(
+      filename: 'fuel-${from.toIso8601String()}-${to.toIso8601String()}.csv',
+      loader: () => _remote.downloadFuel({
+        'from': from.toIso8601String(),
+        'to': to.toIso8601String(),
+      }),
+      demoContent: _demoFuelCsv(from, to),
+    );
+  }
+
+  @override
+  Future<String> downloadToolsReport({required DateTime from, required DateTime to}) {
+    return _download(
+      filename: 'tools-${from.toIso8601String()}-${to.toIso8601String()}.csv',
+      loader: () => _remote.downloadTools({
+        'from': from.toIso8601String(),
+        'to': to.toIso8601String(),
+      }),
+      demoContent: _demoToolsCsv(from, to),
+    );
+  }
+
+  Future<String> _download({
+    required String filename,
+    required Future<List<int>> Function() loader,
+    required String demoContent,
+  }) async {
+    try {
+      final bytes = _config.isDemoMode ? utf8.encode(demoContent) : await loader();
+      final savedPath = await _fileSaver.saveBytes(filename, bytes);
+      return savedPath;
+    } on AppError catch (error) {
+      _logger.warn('Download report failed', error);
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.error('Unexpected report download error', error, stackTrace);
+      rethrow;
+    }
+  }
+
+  String _demoAlertsCsv(DateTime from, DateTime to) {
+    return 'id,type,severity,createdAt\n'
+        'a-1,Temperatura,high,${from.toIso8601String()}\n'
+        'a-2,Movimiento,medium,${to.toIso8601String()}';
+  }
+
+  String _demoFuelCsv(DateTime from, DateTime to) {
+    return 'id,vehicle,operator,liters,timestamp\n'
+        'f-1,truck-1,op-1,120,${from.toIso8601String()}\n'
+        'f-2,truck-2,op-2,80,${to.toIso8601String()}';
+  }
+
+  String _demoToolsCsv(DateTime from, DateTime to) {
+    return 'id,tool,operator,type,timestamp\n'
+        't-1,Taladro,op-1,checkout,${from.toIso8601String()}\n'
+        't-2,Sierra,op-2,return,${to.toIso8601String()}';
+  }
+}

--- a/lib/data/tools/datasources/tools_local_data_source.dart
+++ b/lib/data/tools/datasources/tools_local_data_source.dart
@@ -1,0 +1,22 @@
+import '../../../core/database/cache_store.dart';
+import '../models/tool_dto.dart';
+
+class ToolsLocalDataSource {
+  ToolsLocalDataSource(this._cacheStore);
+
+  final CacheStore _cacheStore;
+
+  static const _toolsType = 'tools';
+
+  Future<void> cacheTools(List<ToolDto> tools) async {
+    await _cacheStore.saveAll(
+      _toolsType,
+      tools.map((dto) => dto.toJson()).toList(),
+    );
+  }
+
+  Future<List<ToolDto>> loadTools() async {
+    final cached = await _cacheStore.readAll(_toolsType);
+    return cached.map(ToolDto.fromJson).toList();
+  }
+}

--- a/lib/data/tools/datasources/tools_remote_data_source.dart
+++ b/lib/data/tools/datasources/tools_remote_data_source.dart
@@ -1,0 +1,29 @@
+import '../../../core/network/http_client.dart';
+import '../models/tool_dto.dart';
+import '../models/tool_movement_dto.dart';
+
+class ToolsRemoteDataSource {
+  ToolsRemoteDataSource(this._client);
+
+  final AppHttpClient _client;
+
+  Future<List<ToolDto>> fetchTools(Map<String, dynamic> params) async {
+    final response = await _client.get<List<dynamic>>(
+      '/tools',
+      queryParameters: params,
+    );
+    final data = response.data ?? const [];
+    return data
+        .whereType<Map<String, dynamic>>()
+        .map(ToolDto.fromJson)
+        .toList();
+  }
+
+  Future<ToolMovementDto> registerMovement(Map<String, dynamic> body) async {
+    final response = await _client.post<Map<String, dynamic>>(
+      '/tools/movements',
+      data: body,
+    );
+    return ToolMovementDto.fromJson(response.data ?? const {});
+  }
+}

--- a/lib/data/tools/models/tool_dto.dart
+++ b/lib/data/tools/models/tool_dto.dart
@@ -1,0 +1,62 @@
+import '../../../domain/tools/tool.dart';
+
+class ToolDto {
+  ToolDto({
+    required this.id,
+    required this.sku,
+    required this.name,
+    required this.status,
+    required this.location,
+    this.thumbnailUrl,
+  });
+
+  final String id;
+  final String sku;
+  final String name;
+  final String status;
+  final String location;
+  final String? thumbnailUrl;
+
+  factory ToolDto.fromJson(Map<String, dynamic> json) {
+    return ToolDto(
+      id: json['id'].toString(),
+      sku: json['sku'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      status: (json['status'] as String? ?? 'available').toLowerCase(),
+      location: json['location'] as String? ?? '',
+      thumbnailUrl: json['thumbnailUrl'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'sku': sku,
+        'name': name,
+        'status': status,
+        'location': location,
+        if (thumbnailUrl != null) 'thumbnailUrl': thumbnailUrl,
+      };
+
+  Tool toDomain() {
+    return Tool(
+      id: id,
+      sku: sku,
+      name: name,
+      status: ToolStatus.values.firstWhere(
+        (value) => value.name == status,
+        orElse: () => ToolStatus.available,
+      ),
+      location: location,
+    );
+  }
+
+  static ToolDto fromDomain(Tool tool) {
+    return ToolDto(
+      id: tool.id,
+      sku: tool.sku,
+      name: tool.name,
+      status: tool.status.name,
+      location: tool.location,
+    );
+  }
+}

--- a/lib/data/tools/models/tool_movement_dto.dart
+++ b/lib/data/tools/models/tool_movement_dto.dart
@@ -1,0 +1,68 @@
+import '../../../domain/tools/tool.dart';
+
+class ToolMovementDto {
+  ToolMovementDto({
+    required this.id,
+    required this.toolId,
+    required this.operatorId,
+    required this.type,
+    this.dueAt,
+    this.returnedAt,
+  });
+
+  final String id;
+  final String toolId;
+  final String operatorId;
+  final String type;
+  final DateTime? dueAt;
+  final DateTime? returnedAt;
+
+  factory ToolMovementDto.fromJson(Map<String, dynamic> json) {
+    return ToolMovementDto(
+      id: json['id'].toString(),
+      toolId: json['toolId'].toString(),
+      operatorId: json['operatorId'].toString(),
+      type: (json['type'] as String? ?? 'checkout').toLowerCase(),
+      dueAt: json['dueAt'] != null
+          ? DateTime.tryParse(json['dueAt'] as String)
+          : null,
+      returnedAt: json['returnedAt'] != null
+          ? DateTime.tryParse(json['returnedAt'] as String)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'toolId': toolId,
+        'operatorId': operatorId,
+        'type': type,
+        if (dueAt != null) 'dueAt': dueAt!.toIso8601String(),
+        if (returnedAt != null) 'returnedAt': returnedAt!.toIso8601String(),
+      };
+
+  ToolMovement toDomain() {
+    return ToolMovement(
+      id: id,
+      toolId: toolId,
+      operatorId: operatorId,
+      type: ToolMovementType.values.firstWhere(
+        (value) => value.name == type,
+        orElse: () => ToolMovementType.checkout,
+      ),
+      dueAt: dueAt,
+      returnedAt: returnedAt,
+    );
+  }
+
+  static ToolMovementDto fromDomain(ToolMovement movement) {
+    return ToolMovementDto(
+      id: movement.id,
+      toolId: movement.toolId,
+      operatorId: movement.operatorId,
+      type: movement.type.name,
+      dueAt: movement.dueAt,
+      returnedAt: movement.returnedAt,
+    );
+  }
+}

--- a/lib/data/tools/tools_repository_impl.dart
+++ b/lib/data/tools/tools_repository_impl.dart
@@ -1,0 +1,154 @@
+import 'package:uuid/uuid.dart';
+
+import '../../core/config/app_config.dart';
+import '../../core/errors/app_error.dart';
+import '../../core/logging/app_logger.dart';
+import '../../core/offline/outbox_service.dart';
+import '../../domain/tools/tool.dart';
+import '../../domain/tools/tools_repository.dart';
+import 'datasources/tools_local_data_source.dart';
+import 'datasources/tools_remote_data_source.dart';
+import 'models/tool_dto.dart';
+import 'models/tool_movement_dto.dart';
+
+class ToolsRepositoryImpl implements ToolsRepository {
+  ToolsRepositoryImpl(
+    this._remote,
+    this._local,
+    this._config,
+    this._outbox,
+    this._logger,
+  );
+
+  final ToolsRemoteDataSource _remote;
+  final ToolsLocalDataSource _local;
+  final AppConfig _config;
+  final OutboxService _outbox;
+  final AppLogger _logger;
+
+  final _uuid = const Uuid();
+
+  List<Tool> _cached = <Tool>[];
+
+  @override
+  Future<List<Tool>> fetchTools({String? status, String? query}) async {
+    final cachedDtos = await _local.loadTools();
+    if (_cached.isEmpty && cachedDtos.isNotEmpty) {
+      _cached = cachedDtos.map((dto) => dto.toDomain()).toList();
+    }
+
+    if (_config.isDemoMode) {
+      _cached = _demoTools;
+      return _cached;
+    }
+
+    final params = <String, dynamic>{
+      'status': status,
+      'q': query,
+    }..removeWhere((key, value) => value == null || (value is String && value.isEmpty));
+
+    try {
+      final dtos = await _remote.fetchTools(params);
+      await _local.cacheTools(dtos);
+      _cached = dtos.map((dto) => dto.toDomain()).toList();
+      return _cached;
+    } on AppError catch (error) {
+      _logger.warn('Failed to fetch tools', error);
+      if (_cached.isNotEmpty && error.code.isNetworkError) {
+        return _cached;
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<ToolMovement> registerMovement(ToolMovement movement) async {
+    final movementWithId = movement.id.isEmpty
+        ? ToolMovement(
+            id: _uuid.v4(),
+            toolId: movement.toolId,
+            operatorId: movement.operatorId,
+            type: movement.type,
+            dueAt: movement.dueAt,
+            returnedAt: movement.returnedAt,
+          )
+        : movement;
+
+    if (_config.isDemoMode) {
+      _cached = _cached
+          .map((tool) => tool.id == movement.toolId
+              ? Tool(
+                  id: tool.id,
+                  sku: tool.sku,
+                  name: tool.name,
+                  status: movement.type == ToolMovementType.checkout
+                      ? ToolStatus.inUse
+                      : ToolStatus.available,
+                  location: tool.location,
+                )
+              : tool)
+          .toList();
+      return movementWithId;
+    }
+
+    final dto = ToolMovementDto.fromDomain(movementWithId);
+    try {
+      final created = await _remote.registerMovement(dto.toJson());
+      _updateCachedStatus(movementWithId);
+      await _local.cacheTools(
+        _cached.map(ToolDto.fromDomain).toList(),
+      );
+      return created.toDomain();
+    } on AppError catch (error) {
+      if (error.code.isNetworkError) {
+        _updateCachedStatus(movementWithId);
+        await _local.cacheTools(
+          _cached.map(ToolDto.fromDomain).toList(),
+        );
+        await _outbox.enqueue(
+          method: 'POST',
+          endpoint: '/tools/movements',
+          body: dto.toJson(),
+          reference: movementWithId.id,
+        );
+        return movementWithId;
+      }
+      rethrow;
+    }
+  }
+
+  void _updateCachedStatus(ToolMovement movement) {
+    _cached = _cached
+        .map(
+          (tool) => tool.id == movement.toolId
+              ? Tool(
+                  id: tool.id,
+                  sku: tool.sku,
+                  name: tool.name,
+                  status: movement.type == ToolMovementType.checkout
+                      ? ToolStatus.inUse
+                      : ToolStatus.available,
+                  location: tool.location,
+                )
+              : tool,
+        )
+        .toList();
+  }
+
+  List<Tool> get _demoTools => <Tool>[
+        Tool(
+          id: 'tool-1',
+          sku: 'SKU-1001',
+          name: 'Taladro industrial',
+          status: ToolStatus.inUse,
+          location: 'Depósito A',
+        ),
+        Tool(
+          id: 'tool-2',
+          sku: 'SKU-2002',
+          name: 'Sensor combustible',
+          status: ToolStatus.available,
+          location: 'Camión 4',
+        ),
+      ];
+}

--- a/lib/domain/admin/admin_repository.dart
+++ b/lib/domain/admin/admin_repository.dart
@@ -1,0 +1,17 @@
+import '../auth/entities/app_user.dart';
+import 'user_account.dart';
+
+abstract class AdminRepository {
+  Future<List<AdminUserAccount>> fetchUsers();
+  Future<AdminUserAccount> createUser({
+    required String username,
+    required String displayName,
+    required UserRole role,
+  });
+  Future<AdminUserAccount> updateUser(
+    String id,
+    Map<String, dynamic> updates,
+  );
+  Future<void> disableUser(String id);
+  Future<List<RolePermissions>> fetchRoles();
+}

--- a/lib/domain/admin/user_account.dart
+++ b/lib/domain/admin/user_account.dart
@@ -1,0 +1,24 @@
+import '../auth/entities/app_user.dart';
+
+class AdminUserAccount {
+  AdminUserAccount({
+    required this.id,
+    required this.username,
+    required this.displayName,
+    required this.role,
+    this.disabled = false,
+  });
+
+  final String id;
+  final String username;
+  final String displayName;
+  final UserRole role;
+  final bool disabled;
+}
+
+class RolePermissions {
+  RolePermissions({required this.role, required this.permissions});
+
+  final UserRole role;
+  final Map<String, bool> permissions;
+}

--- a/lib/domain/alerts/alert.dart
+++ b/lib/domain/alerts/alert.dart
@@ -1,0 +1,27 @@
+enum AlertSeverity { low, medium, high, critical }
+
+enum AlertSource { camera, fuel, tools, system }
+
+class Alert {
+  Alert({
+    required this.id,
+    required this.type,
+    required this.severity,
+    required this.source,
+    required this.createdAt,
+    this.resolvedAt,
+    this.assignedTo,
+    this.payload,
+  });
+
+  final String id;
+  final String type;
+  final AlertSeverity severity;
+  final AlertSource source;
+  final DateTime createdAt;
+  DateTime? resolvedAt;
+  String? assignedTo;
+  Map<String, dynamic>? payload;
+
+  bool get isResolved => resolvedAt != null;
+}

--- a/lib/domain/alerts/alerts_repository.dart
+++ b/lib/domain/alerts/alerts_repository.dart
@@ -1,0 +1,18 @@
+import 'alert.dart';
+
+abstract class AlertsRepository {
+  Stream<List<Alert>> watchAlerts();
+
+  Future<List<Alert>> fetchAlerts({
+    DateTime? from,
+    DateTime? to,
+    String? severity,
+    String? source,
+    int? page,
+    int? pageSize,
+  });
+
+  Future<Alert> getAlert(String id);
+
+  Future<Alert> resolveAlert(String id);
+}

--- a/lib/domain/auth/entities/app_user.dart
+++ b/lib/domain/auth/entities/app_user.dart
@@ -1,0 +1,15 @@
+enum UserRole { admin, supervisor, operario, viewer }
+
+class AppUser {
+  const AppUser({
+    required this.id,
+    required this.username,
+    required this.displayName,
+    required this.role,
+  });
+
+  final String id;
+  final String username;
+  final String displayName;
+  final UserRole role;
+}

--- a/lib/domain/auth/entities/auth_session.dart
+++ b/lib/domain/auth/entities/auth_session.dart
@@ -1,0 +1,18 @@
+import 'app_user.dart';
+
+class AuthSession {
+  const AuthSession({
+    required this.user,
+    required this.tokens,
+  });
+
+  final AppUser user;
+  final SessionTokens tokens;
+}
+
+class SessionTokens {
+  const SessionTokens({required this.token, required this.refreshToken});
+
+  final String token;
+  final String refreshToken;
+}

--- a/lib/domain/auth/repositories/auth_repository.dart
+++ b/lib/domain/auth/repositories/auth_repository.dart
@@ -1,0 +1,17 @@
+import '../entities/app_user.dart';
+import '../entities/auth_session.dart';
+
+abstract class AuthRepository {
+  Future<AuthSession> login({
+    required String username,
+    required String password,
+  });
+
+  Future<AuthSession?> loadCurrentSession();
+
+  Future<AppUser> refreshUser();
+
+  Future<bool> refreshToken();
+
+  Future<void> logout();
+}

--- a/lib/domain/cameras/camera.dart
+++ b/lib/domain/cameras/camera.dart
@@ -1,0 +1,21 @@
+enum CameraStatus { online, offline }
+
+class Camera {
+  Camera({
+    required this.id,
+    required this.name,
+    required this.location,
+    required this.status,
+    this.streamUrl,
+    this.streamHls,
+    this.thumbnailUrl,
+  });
+
+  final String id;
+  final String name;
+  final String location;
+  final CameraStatus status;
+  final String? streamUrl;
+  final String? streamHls;
+  final String? thumbnailUrl;
+}

--- a/lib/domain/cameras/cameras_repository.dart
+++ b/lib/domain/cameras/cameras_repository.dart
@@ -1,0 +1,6 @@
+import 'camera.dart';
+
+abstract class CamerasRepository {
+  Future<List<Camera>> fetchCameras();
+  Future<Camera> getCamera(String id);
+}

--- a/lib/domain/fuel/fuel_event.dart
+++ b/lib/domain/fuel/fuel_event.dart
@@ -1,0 +1,26 @@
+enum FuelSource { esp32, manual }
+
+class FuelEvent {
+  FuelEvent({
+    required this.id,
+    required this.vehicleId,
+    required this.operatorId,
+    required this.liters,
+    required this.timestamp,
+    required this.source,
+  });
+
+  final String id;
+  final String vehicleId;
+  final String operatorId;
+  final double liters;
+  final DateTime timestamp;
+  final FuelSource source;
+}
+
+class FuelKpis {
+  FuelKpis({required this.range, required this.totalLiters});
+
+  final String range;
+  final double totalLiters;
+}

--- a/lib/domain/fuel/fuel_repository.dart
+++ b/lib/domain/fuel/fuel_repository.dart
@@ -1,0 +1,15 @@
+import 'fuel_event.dart';
+
+abstract class FuelRepository {
+  Future<List<FuelEvent>> fetchEvents({
+    DateTime? from,
+    DateTime? to,
+    String? vehicle,
+    String? operatorId,
+    int? page,
+  });
+
+  Future<FuelEvent> createEvent(FuelEvent event);
+
+  Future<FuelKpis> fetchKpis({required String range});
+}

--- a/lib/domain/operators/operator.dart
+++ b/lib/domain/operators/operator.dart
@@ -1,0 +1,21 @@
+enum OperatorStatus { active, inactive, suspended }
+
+enum OperatorRole { admin, supervisor, operario, viewer }
+
+class Operator {
+  Operator({
+    required this.id,
+    required this.name,
+    required this.role,
+    required this.area,
+    required this.status,
+    this.lastSeenAt,
+  });
+
+  final String id;
+  final String name;
+  final OperatorRole role;
+  final String area;
+  final OperatorStatus status;
+  final DateTime? lastSeenAt;
+}

--- a/lib/domain/operators/operators_repository.dart
+++ b/lib/domain/operators/operators_repository.dart
@@ -1,0 +1,8 @@
+import 'operator.dart';
+
+abstract class OperatorsRepository {
+  Future<List<Operator>> fetchOperators({String? query, String? status});
+  Future<Operator> getOperator(String id);
+  Future<Operator> createOperator(Operator operator);
+  Future<Operator> updateOperator(String id, Map<String, dynamic> updates);
+}

--- a/lib/domain/projects/project.dart
+++ b/lib/domain/projects/project.dart
@@ -1,0 +1,23 @@
+enum ProjectStatus { planned, active, paused, completed }
+
+class Project {
+  Project({
+    required this.id,
+    required this.name,
+    required this.status,
+    required this.progressPct,
+    required this.ownerId,
+    required this.startAt,
+    this.endAt,
+    this.budget,
+  });
+
+  final String id;
+  final String name;
+  final ProjectStatus status;
+  final double progressPct;
+  final String ownerId;
+  final DateTime startAt;
+  final DateTime? endAt;
+  final double? budget;
+}

--- a/lib/domain/projects/projects_repository.dart
+++ b/lib/domain/projects/projects_repository.dart
@@ -1,0 +1,8 @@
+import 'project.dart';
+
+abstract class ProjectsRepository {
+  Future<List<Project>> fetchProjects({String? query, String? status});
+  Future<Project> getProject(String id);
+  Future<Project> createProject(Project project);
+  Future<Project> updateProject(String id, Map<String, dynamic> updates);
+}

--- a/lib/domain/reports/reports_repository.dart
+++ b/lib/domain/reports/reports_repository.dart
@@ -1,0 +1,7 @@
+abstract class ReportsRepository {
+  Future<String> downloadAlertsReport({required DateTime from, required DateTime to});
+
+  Future<String> downloadFuelReport({required DateTime from, required DateTime to});
+
+  Future<String> downloadToolsReport({required DateTime from, required DateTime to});
+}

--- a/lib/domain/tools/tool.dart
+++ b/lib/domain/tools/tool.dart
@@ -1,0 +1,37 @@
+enum ToolStatus { available, inUse, missing }
+
+enum ToolMovementType { checkout, return }
+
+class Tool {
+  Tool({
+    required this.id,
+    required this.sku,
+    required this.name,
+    required this.status,
+    required this.location,
+  });
+
+  final String id;
+  final String sku;
+  final String name;
+  final ToolStatus status;
+  final String location;
+}
+
+class ToolMovement {
+  ToolMovement({
+    required this.id,
+    required this.toolId,
+    required this.operatorId,
+    required this.type,
+    this.dueAt,
+    this.returnedAt,
+  });
+
+  final String id;
+  final String toolId;
+  final String operatorId;
+  final ToolMovementType type;
+  final DateTime? dueAt;
+  final DateTime? returnedAt;
+}

--- a/lib/domain/tools/tools_repository.dart
+++ b/lib/domain/tools/tools_repository.dart
@@ -1,0 +1,7 @@
+import 'tool.dart';
+
+abstract class ToolsRepository {
+  Future<List<Tool>> fetchTools({String? status, String? query});
+
+  Future<ToolMovement> registerMovement(ToolMovement movement);
+}

--- a/lib/features/admin/users/admin_users_controller.dart
+++ b/lib/features/admin/users/admin_users_controller.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../domain/admin/admin_repository.dart';
+import '../../../domain/admin/user_account.dart';
+import '../../../domain/auth/entities/app_user.dart';
+
+class AdminUsersController extends ChangeNotifier {
+  AdminUsersController(this._repository);
+
+  final AdminRepository _repository;
+
+  List<AdminUserAccount> _users = <AdminUserAccount>[];
+  List<RolePermissions> _roles = <RolePermissions>[];
+  bool _loading = false;
+  AppError? _error;
+
+  List<AdminUserAccount> get users => _users;
+  List<RolePermissions> get roles => _roles;
+  bool get isLoading => _loading;
+  AppError? get error => _error;
+
+  Future<void> load() async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _users = await _repository.fetchUsers();
+      _roles = await _repository.fetchRoles();
+    } on AppError catch (error) {
+      _error = error;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> createUser({
+    required String username,
+    required String displayName,
+    required UserRole role,
+  }) async {
+    try {
+      final user = await _repository.createUser(
+        username: username,
+        displayName: displayName,
+        role: role,
+      );
+      _users = [..._users, user];
+      notifyListeners();
+    } on AppError catch (error) {
+      _error = error;
+      notifyListeners();
+    }
+  }
+
+  Future<void> disableUser(String id) async {
+    try {
+      await _repository.disableUser(id);
+      _users = _users
+          .map((user) => user.id == id
+              ? AdminUserAccount(
+                  id: user.id,
+                  username: user.username,
+                  displayName: user.displayName,
+                  role: user.role,
+                  disabled: true,
+                )
+              : user)
+          .toList();
+      notifyListeners();
+    } on AppError catch (error) {
+      _error = error;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/admin/users/admin_users_screen.dart
+++ b/lib/features/admin/users/admin_users_screen.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../domain/admin/admin_repository.dart';
+import '../../../domain/admin/user_account.dart';
+import '../../../domain/auth/entities/app_user.dart';
+import 'admin_users_controller.dart';
+
+class AdminUsersScreen extends StatefulWidget {
+  const AdminUsersScreen({super.key});
+
+  @override
+  State<AdminUsersScreen> createState() => _AdminUsersScreenState();
+}
+
+class _AdminUsersScreenState extends State<AdminUsersScreen> {
+  late final AdminUsersController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AdminUsersController(context.read<AdminRepository>())
+      ..addListener(_onUpdate)
+      ..load();
+  }
+
+  void _onUpdate() => setState(() {});
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onUpdate);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Usuarios y roles')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showCreateDialog(context),
+        child: const Icon(Icons.add),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: _Content(controller: _controller),
+      ),
+    );
+  }
+
+  Future<void> _showCreateDialog(BuildContext context) async {
+    final usernameController = TextEditingController();
+    final nameController = TextEditingController();
+    UserRole selectedRole = UserRole.viewer;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setLocalState) {
+            return AlertDialog(
+              title: const Text('Nuevo usuario'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: usernameController,
+                    decoration: const InputDecoration(labelText: 'Usuario'),
+                  ),
+                  TextField(
+                    controller: nameController,
+                    decoration:
+                        const InputDecoration(labelText: 'Nombre visible'),
+                  ),
+                  DropdownButton<UserRole>(
+                    value: selectedRole,
+                    onChanged: (value) {
+                      if (value != null) {
+                        setLocalState(() => selectedRole = value);
+                      }
+                    },
+                    items: UserRole.values
+                        .map((role) => DropdownMenuItem(
+                              value: role,
+                              child: Text(role.name),
+                            ))
+                        .toList(),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('Cancelar'),
+                ),
+                ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(true),
+                  child: const Text('Crear'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+    if (result == true) {
+      await _controller.createUser(
+        username: usernameController.text.trim(),
+        displayName: nameController.text.trim(),
+        role: selectedRole,
+      );
+      if (_controller.error != null && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(_controller.error!.message)),
+        );
+      }
+    }
+  }
+}
+
+class _Content extends StatelessWidget {
+  const _Content({required this.controller});
+
+  final AdminUsersController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (controller.isLoading) {
+      return const _Skeleton();
+    }
+    if (controller.error != null && controller.users.isEmpty) {
+      return _ErrorState(error: controller.error!, onRetry: controller.load);
+    }
+    final users = controller.users;
+    if (users.isEmpty) {
+      return _EmptyState(onRetry: controller.load);
+    }
+    return RefreshIndicator(
+      onRefresh: controller.load,
+      child: ListView.builder(
+        itemCount: users.length,
+        itemBuilder: (context, index) {
+          final user = users[index];
+          return Card(
+            child: ListTile(
+              leading: Icon(user.disabled ? Icons.block : Icons.person),
+              title: Text(user.displayName),
+              subtitle: Text('${user.username} • ${user.role.name}'),
+              trailing: user.disabled
+                  ? const Text('Deshabilitado')
+                  : TextButton(
+                      onPressed: () => controller.disableUser(user.id),
+                      child: const Text('Deshabilitar'),
+                    ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Skeleton extends StatelessWidget {
+  const _Skeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: 4,
+      itemBuilder: (context, index) => const ListTile(
+        leading: CircleAvatar(backgroundColor: Colors.grey),
+        title: SizedBox(height: 12, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+        subtitle: SizedBox(height: 10, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onRetry});
+
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('No hay usuarios administrables'),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Actualizar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.error, required this.onRetry});
+
+  final AppError error;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(error.message),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Reintentar'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/alerts/presentation/alerts_controller.dart
+++ b/lib/features/alerts/presentation/alerts_controller.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../domain/alerts/alert.dart';
+import '../../../data/alerts/alerts_repository_impl.dart';
+
+class AlertsController extends ChangeNotifier {
+  AlertsController(this._repository);
+
+  final AlertsRepositoryImpl _repository;
+
+  StreamSubscription<List<Alert>>? _subscription;
+  List<Alert> _alerts = <Alert>[];
+  bool _loading = false;
+  AppError? _error;
+
+  List<Alert> get alerts => _alerts;
+  bool get isLoading => _loading;
+  AppError? get error => _error;
+
+  void start() {
+    _loading = true;
+    notifyListeners();
+    _subscription = _repository.watchAlerts().listen(
+      (alerts) {
+        _alerts = alerts;
+        _loading = false;
+        _error = null;
+        notifyListeners();
+      },
+      onError: (error) {
+        if (error is AppError) {
+          _error = error;
+        }
+        _loading = false;
+        notifyListeners();
+      },
+    );
+    _repository.fetchAlerts();
+  }
+
+  Future<void> refresh() => _repository.fetchAlerts();
+
+  Future<void> resolve(String id) async {
+    try {
+      await _repository.resolveAlert(id);
+    } on AppError catch (error) {
+      _error = error;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/alerts/presentation/alerts_list_screen.dart
+++ b/lib/features/alerts/presentation/alerts_list_screen.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../data/alerts/alerts_repository_impl.dart';
+import '../../../domain/alerts/alert.dart';
+import 'alerts_controller.dart';
+
+class AlertsListScreen extends StatefulWidget {
+  const AlertsListScreen({super.key});
+
+  @override
+  State<AlertsListScreen> createState() => _AlertsListScreenState();
+}
+
+class _AlertsListScreenState extends State<AlertsListScreen> {
+  late final AlertsController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AlertsController(context.read<AlertsRepositoryImpl>())..start();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Alertas')),
+      body: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, _) {
+          if (_controller.isLoading) {
+            return const _AlertsSkeleton();
+          }
+          if (_controller.error != null) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(_controller.error!.message),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: _controller.refresh,
+                    child: const Text('Reintentar'),
+                  ),
+                ],
+              ),
+            );
+          }
+          final alerts = _controller.alerts;
+          if (alerts.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('No hay alertas activas'),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: _controller.refresh,
+                    child: const Text('Actualizar'),
+                  ),
+                ],
+              ),
+            );
+          }
+          return RefreshIndicator(
+            onRefresh: _controller.refresh,
+            child: ListView.builder(
+              itemCount: alerts.length,
+              itemBuilder: (context, index) {
+                final alert = alerts[index];
+                return _AlertTile(
+                  alert: alert,
+                  onResolve: () => _controller.resolve(alert.id),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AlertsSkeleton extends StatelessWidget {
+  const _AlertsSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: 4,
+      itemBuilder: (context, index) => const ListTile(
+        leading: CircleAvatar(backgroundColor: Colors.grey),
+        title: SizedBox(height: 12, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+        subtitle: SizedBox(height: 10, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+      ),
+    );
+  }
+}
+
+class _AlertTile extends StatelessWidget {
+  const _AlertTile({required this.alert, required this.onResolve});
+
+  final Alert alert;
+  final VoidCallback onResolve;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: ListTile(
+        leading: Icon(_iconForSeverity(alert.severity)),
+        title: Text(alert.type),
+        subtitle: Text('${alert.source.name} • ${alert.createdAt}'),
+        trailing: alert.isResolved
+            ? const Icon(Icons.check_circle, color: Colors.green)
+            : TextButton(
+                onPressed: onResolve,
+                child: const Text('Resolver'),
+              ),
+      ),
+    );
+  }
+
+  IconData _iconForSeverity(AlertSeverity severity) {
+    switch (severity) {
+      case AlertSeverity.critical:
+        return Icons.error;
+      case AlertSeverity.high:
+        return Icons.warning;
+      case AlertSeverity.medium:
+        return Icons.info_outline;
+      case AlertSeverity.low:
+        return Icons.notifications_none;
+    }
+  }
+}

--- a/lib/features/auth/controllers/auth_controller.dart
+++ b/lib/features/auth/controllers/auth_controller.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../core/errors/app_error.dart';
+import '../../../core/logging/app_logger.dart';
+import '../../../core/ws/alerts_realtime_service.dart';
+import '../../../data/alerts/alerts_repository_impl.dart';
+import '../../../domain/auth/entities/auth_session.dart';
+import '../../../domain/auth/repositories/auth_repository.dart';
+import '../../../domain/alerts/alert.dart';
+
+class AuthController extends ChangeNotifier {
+  AuthController(
+    this._authRepository,
+    this._alertsRepository,
+    this._alertsRealtimeService,
+    this._logger,
+  );
+
+  final AuthRepository _authRepository;
+  final AlertsRepositoryImpl _alertsRepository;
+  final AlertsRealtimeService _alertsRealtimeService;
+  final AppLogger _logger;
+
+  AuthSession? _session;
+  bool _isLoading = false;
+  AppError? _error;
+
+  AuthSession? get session => _session;
+  bool get isLoading => _isLoading;
+  AppError? get error => _error;
+  bool get isAuthenticated => _session != null;
+
+  Future<void> initialize() async {
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final current = await _authRepository.loadCurrentSession();
+      _session = current;
+      if (_session != null) {
+        await _startRealtime();
+      }
+    } catch (error, stackTrace) {
+      _logger.error('Failed to load session', error, stackTrace);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> login(String username, String password) async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      final session = await _authRepository.login(
+        username: username.trim(),
+        password: password.trim(),
+      );
+      _session = session;
+      await _startRealtime();
+      _isLoading = false;
+      notifyListeners();
+      return true;
+    } on AppError catch (error) {
+      _error = error;
+      _isLoading = false;
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<void> logout() async {
+    await _alertsRealtimeService.stop();
+    await _authRepository.logout();
+    _session = null;
+    notifyListeners();
+  }
+
+  Future<void> _startRealtime() async {
+    final session = _session;
+    if (session == null) {
+      return;
+    }
+    await _alertsRealtimeService.start(
+      token: session.tokens.token,
+      onMessage: (message) async {
+        final alert = Alert(
+          id: message['id'].toString(),
+          type: message['type'] as String? ?? '',
+          severity: AlertSeverity.values.firstWhere(
+            (value) => value.name ==
+                (message['severity'] as String? ?? 'low').toLowerCase(),
+            orElse: () => AlertSeverity.low,
+          ),
+          source: AlertSource.values.firstWhere(
+            (value) => value.name ==
+                (message['source'] as String? ?? 'system').toLowerCase(),
+            orElse: () => AlertSource.system,
+          ),
+          createdAt: DateTime.tryParse(message['createdAt'] as String? ?? '') ??
+              DateTime.now(),
+          resolvedAt: message['resolvedAt'] != null
+              ? DateTime.tryParse(message['resolvedAt'] as String)
+              : null,
+          assignedTo: message['assignedTo'] as String?,
+          payload: message['payload'] as Map<String, dynamic>?,
+        );
+        await _alertsRepository.addRealtimeAlert(alert);
+      },
+    );
+  }
+
+  Future<void> refreshUser() async {
+    try {
+      final updated = await _authRepository.refreshUser();
+      if (_session != null) {
+        _session = AuthSession(
+          user: updated,
+          tokens: _session!.tokens,
+        );
+        notifyListeners();
+      }
+    } catch (error, stackTrace) {
+      _logger.warn('Failed to refresh user', error, stackTrace);
+    }
+  }
+}

--- a/lib/features/auth/presentation/login_screen.dart
+++ b/lib/features/auth/presentation/login_screen.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../controllers/auth_controller.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthController>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('SAMI - Iniciar sesión')),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 400),
+            child: Card(
+              elevation: 3,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Accedé a tu panel',
+                      style:
+                          TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 16),
+                    Form(
+                      key: _formKey,
+                      child: Column(
+                        children: [
+                          TextFormField(
+                            controller: _usernameController,
+                            decoration: const InputDecoration(
+                              labelText: 'Usuario',
+                              border: OutlineInputBorder(),
+                            ),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'Ingresá tu usuario';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 16),
+                          TextFormField(
+                            controller: _passwordController,
+                            decoration: const InputDecoration(
+                              labelText: 'Contraseña',
+                              border: OutlineInputBorder(),
+                            ),
+                            obscureText: true,
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return 'Ingresá tu contraseña';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 24),
+                          SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton(
+                              onPressed: auth.isLoading
+                                  ? null
+                                  : () async {
+                                      if (_formKey.currentState?.validate() ??
+                                          false) {
+                                        final success = await auth.login(
+                                          _usernameController.text,
+                                          _passwordController.text,
+                                        );
+                                        if (!success && mounted) {
+                                          ScaffoldMessenger.of(context)
+                                              .showSnackBar(
+                                            SnackBar(
+                                              content: Text(
+                                                auth.error?.message ??
+                                                    'No se pudo iniciar sesión',
+                                              ),
+                                            ),
+                                          );
+                                        }
+                                      }
+                                    },
+                              child: auth.isLoading
+                                  ? const SizedBox(
+                                      height: 18,
+                                      width: 18,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        valueColor:
+                                            AlwaysStoppedAnimation<Color>(
+                                          Colors.white,
+                                        ),
+                                      ),
+                                    )
+                                  : const Text('Ingresar'),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          if (auth.error != null)
+                            Text(
+                              auth.error!.message,
+                              style: const TextStyle(color: Colors.red),
+                            ),
+                          const SizedBox(height: 12),
+                          const Text(
+                            'Usuario demo: ClaudioC / ABCD1234',
+                            style: TextStyle(fontSize: 12),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/dashboard_controller.dart
+++ b/lib/features/dashboard/dashboard_controller.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/foundation.dart';
+
+import '../../core/errors/app_error.dart';
+import '../../domain/alerts/alert.dart';
+import '../../domain/cameras/cameras_repository.dart';
+import '../../domain/fuel/fuel_repository.dart';
+import '../../domain/tools/tools_repository.dart';
+import '../../data/alerts/alerts_repository_impl.dart';
+
+class DashboardState {
+  const DashboardState({
+    required this.alerts,
+    required this.activeAlerts,
+    required this.onlineCameras,
+    required this.weeklyFuelLiters,
+    required this.toolsInUse,
+  });
+
+  final List<Alert> alerts;
+  final int activeAlerts;
+  final int onlineCameras;
+  final double weeklyFuelLiters;
+  final int toolsInUse;
+}
+
+class DashboardController extends ChangeNotifier {
+  DashboardController(
+    this._alertsRepository,
+    this._camerasRepository,
+    this._fuelRepository,
+    this._toolsRepository,
+  );
+
+  final AlertsRepositoryImpl _alertsRepository;
+  final CamerasRepository _camerasRepository;
+  final FuelRepository _fuelRepository;
+  final ToolsRepository _toolsRepository;
+
+  DashboardState? _state;
+  bool _loading = false;
+  AppError? _error;
+
+  DashboardState? get state => _state;
+  bool get isLoading => _loading;
+  AppError? get error => _error;
+
+  Future<void> load() async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      final alerts = await _alertsRepository.fetchAlerts(
+        from: DateTime.now().subtract(const Duration(hours: 24)),
+      );
+      final cameras = await _camerasRepository.fetchCameras();
+      final fuelKpis = await _fuelRepository.fetchKpis(range: 'week');
+      final tools = await _toolsRepository.fetchTools(status: 'in_use');
+      final activeAlerts = alerts.where((alert) => !alert.isResolved).length;
+      final onlineCameras = cameras
+          .where((camera) => camera.status == CameraStatus.online)
+          .length;
+      _state = DashboardState(
+        alerts: alerts,
+        activeAlerts: activeAlerts,
+        onlineCameras: onlineCameras,
+        weeklyFuelLiters: fuelKpis.totalLiters,
+        toolsInUse: tools.length,
+      );
+    } on AppError catch (error) {
+      _error = error;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../../data/alerts/alerts_repository_impl.dart';
+import '../../domain/cameras/cameras_repository.dart';
+import '../../domain/fuel/fuel_repository.dart';
+import '../../domain/tools/tools_repository.dart';
+import '../auth/controllers/auth_controller.dart';
+import 'dashboard_controller.dart';
+
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  late final DashboardController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    final alertsRepository = context.read<AlertsRepositoryImpl>();
+    final camerasRepository = context.read<CamerasRepository>();
+    final fuelRepository = context.read<FuelRepository>();
+    final toolsRepository = context.read<ToolsRepository>();
+    _controller = DashboardController(
+      alertsRepository,
+      camerasRepository,
+      fuelRepository,
+      toolsRepository,
+    )
+      ..addListener(_onUpdate)
+      ..load();
+  }
+
+  void _onUpdate() {
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onUpdate);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthController>();
+    final state = _controller.state;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Panel SAMI'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () => context.read<AuthController>().logout(),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Bienvenido, ${auth.session?.user.displayName ?? ''}',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 16),
+            if (_controller.isLoading)
+              const Center(child: CircularProgressIndicator())
+            else if (_controller.error != null)
+              Center(
+                child: Column(
+                  children: [
+                    Text(_controller.error!.message),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _controller.load,
+                      child: const Text('Reintentar'),
+                    ),
+                  ],
+                ),
+              )
+            else if (state == null)
+              const Center(child: Text('Sin datos disponibles'))
+            else
+              Expanded(
+                child: ListView(
+                  children: [
+                    _MetricCard(
+                      title: 'Alertas activas',
+                      value: state.activeAlerts.toString(),
+                      onTap: () => context.push('/alerts'),
+                    ),
+                    const SizedBox(height: 12),
+                    _MetricCard(
+                      title: 'Cámaras online',
+                      value: state.onlineCameras.toString(),
+                      onTap: () {},
+                    ),
+                    const SizedBox(height: 12),
+                    _MetricCard(
+                      title: 'Combustible semana (L)',
+                      value: state.weeklyFuelLiters.toStringAsFixed(1),
+                      onTap: () => context.push('/fuel'),
+                    ),
+                    const SizedBox(height: 12),
+                    _MetricCard(
+                      title: 'Herramientas en uso',
+                      value: state.toolsInUse.toString(),
+                      onTap: () => context.push('/tools'),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  const _MetricCard({required this.title, required this.value, this.onTap});
+
+  final String title;
+  final String value;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: Theme.of(context).colorScheme.surfaceVariant,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            Text(
+              value,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium
+                  ?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/fuel/fuel_controller.dart
+++ b/lib/features/fuel/fuel_controller.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+
+import '../../core/errors/app_error.dart';
+import '../../domain/fuel/fuel_event.dart';
+import '../../domain/fuel/fuel_repository.dart';
+
+class FuelController extends ChangeNotifier {
+  FuelController(this._repository);
+
+  final FuelRepository _repository;
+
+  List<FuelEvent> _events = <FuelEvent>[];
+  bool _loading = false;
+  AppError? _error;
+
+  List<FuelEvent> get events => _events;
+  bool get isLoading => _loading;
+  AppError? get error => _error;
+
+  Future<void> load() async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _events = await _repository.fetchEvents(
+        from: DateTime.now().subtract(const Duration(days: 7)),
+      );
+    } on AppError catch (error) {
+      _error = error;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/fuel/fuel_screen.dart
+++ b/lib/features/fuel/fuel_screen.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../domain/fuel/fuel_event.dart';
+import '../../domain/fuel/fuel_repository.dart';
+import '../../core/errors/app_error.dart';
+import 'fuel_controller.dart';
+
+class FuelScreen extends StatefulWidget {
+  const FuelScreen({super.key});
+
+  @override
+  State<FuelScreen> createState() => _FuelScreenState();
+}
+
+class _FuelScreenState extends State<FuelScreen> {
+  late final FuelController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = FuelController(context.read<FuelRepository>())
+      ..addListener(_onUpdate)
+      ..load();
+  }
+
+  void _onUpdate() => setState(() {});
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onUpdate);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Eventos de combustible')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: _Content(controller: _controller),
+      ),
+    );
+  }
+}
+
+class _Content extends StatelessWidget {
+  const _Content({required this.controller});
+
+  final FuelController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (controller.isLoading) {
+      return const _Skeleton();
+    }
+    if (controller.error != null) {
+      return _ErrorState(error: controller.error!, onRetry: controller.load);
+    }
+    final events = controller.events;
+    if (events.isEmpty) {
+      return _EmptyState(onRetry: controller.load);
+    }
+    return RefreshIndicator(
+      onRefresh: controller.load,
+      child: ListView.builder(
+        itemCount: events.length,
+        itemBuilder: (context, index) {
+          final event = events[index];
+          return Card(
+            child: ListTile(
+              leading: Icon(event.source == FuelSource.esp32
+                  ? Icons.sensors
+                  : Icons.edit),
+              title: Text('${event.vehicleId} • ${event.liters.toStringAsFixed(1)} L'),
+              subtitle: Text('${event.operatorId} • ${event.timestamp}'),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Skeleton extends StatelessWidget {
+  const _Skeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: 4,
+      itemBuilder: (context, index) => const ListTile(
+        leading: CircleAvatar(backgroundColor: Colors.grey),
+        title: SizedBox(height: 12, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+        subtitle: SizedBox(height: 10, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onRetry});
+
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('No hay eventos registrados'),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Actualizar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.error, required this.onRetry});
+
+  final AppError error;
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(error.message),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Reintentar'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/operators/operators_controller.dart
+++ b/lib/features/operators/operators_controller.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+import '../../core/errors/app_error.dart';
+import '../../domain/operators/operator.dart';
+import '../../domain/operators/operators_repository.dart';
+
+class OperatorsController extends ChangeNotifier {
+  OperatorsController(this._repository);
+
+  final OperatorsRepository _repository;
+
+  List<Operator> _operators = <Operator>[];
+  bool _loading = false;
+  AppError? _error;
+
+  List<Operator> get operators => _operators;
+  bool get isLoading => _loading;
+  AppError? get error => _error;
+
+  Future<void> load({String? status}) async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _operators = await _repository.fetchOperators(status: status);
+    } on AppError catch (error) {
+      _error = error;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/operators/operators_screen.dart
+++ b/lib/features/operators/operators_screen.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/errors/app_error.dart';
+import '../../domain/operators/operator.dart';
+import '../../domain/operators/operators_repository.dart';
+import 'operators_controller.dart';
+
+class OperatorsScreen extends StatefulWidget {
+  const OperatorsScreen({super.key});
+
+  @override
+  State<OperatorsScreen> createState() => _OperatorsScreenState();
+}
+
+class _OperatorsScreenState extends State<OperatorsScreen> {
+  late final OperatorsController _controller;
+  String? _status;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = OperatorsController(context.read<OperatorsRepository>())
+      ..addListener(_onUpdate)
+      ..load();
+  }
+
+  void _onUpdate() => setState(() {});
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onUpdate);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Operarios'),
+        actions: [
+          PopupMenuButton<String?>(
+            initialValue: _status,
+            onSelected: (value) {
+              setState(() => _status = value);
+              _controller.load(status: value);
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: null, child: Text('Todos')),
+              PopupMenuItem(value: 'active', child: Text('Activos')),
+              PopupMenuItem(value: 'inactive', child: Text('Inactivos')),
+              PopupMenuItem(value: 'suspended', child: Text('Suspendidos')),
+            ],
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: _Content(controller: _controller),
+      ),
+    );
+  }
+}
+
+class _Content extends StatelessWidget {
+  const _Content({required this.controller});
+
+  final OperatorsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (controller.isLoading) {
+      return const _Skeleton();
+    }
+    if (controller.error != null) {
+      return _ErrorState(error: controller.error!, onRetry: controller.load);
+    }
+    final operators = controller.operators;
+    if (operators.isEmpty) {
+      return _EmptyState(onRetry: controller.load);
+    }
+    return RefreshIndicator(
+      onRefresh: controller.load,
+      child: ListView.builder(
+        itemCount: operators.length,
+        itemBuilder: (context, index) {
+          final operator = operators[index];
+          return Card(
+            child: ListTile(
+              leading: Icon(_iconForStatus(operator.status)),
+              title: Text(operator.name),
+              subtitle: Text('${operator.role.name} • ${operator.area}'),
+              trailing: Text(
+                operator.lastSeenAt != null
+                    ? 'Último: ${operator.lastSeenAt}'
+                    : 'Sin datos',
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  IconData _iconForStatus(OperatorStatus status) {
+    switch (status) {
+      case OperatorStatus.active:
+        return Icons.verified_user;
+      case OperatorStatus.inactive:
+        return Icons.person_off;
+      case OperatorStatus.suspended:
+        return Icons.warning;
+    }
+  }
+}
+
+class _Skeleton extends StatelessWidget {
+  const _Skeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: 4,
+      itemBuilder: (context, index) => const ListTile(
+        leading: CircleAvatar(backgroundColor: Colors.grey),
+        title: SizedBox(height: 12, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+        subtitle: SizedBox(height: 10, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onRetry});
+
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('No se encontraron operarios'),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Actualizar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.error, required this.onRetry});
+
+  final AppError error;
+  final Future<void> Function({String? status}) onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(error.message),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => onRetry(),
+            child: const Text('Reintentar'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/projects/projects_controller.dart
+++ b/lib/features/projects/projects_controller.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+import '../../core/errors/app_error.dart';
+import '../../domain/projects/project.dart';
+import '../../domain/projects/projects_repository.dart';
+
+class ProjectsController extends ChangeNotifier {
+  ProjectsController(this._repository);
+
+  final ProjectsRepository _repository;
+
+  List<Project> _projects = <Project>[];
+  bool _loading = false;
+  AppError? _error;
+
+  List<Project> get projects => _projects;
+  bool get isLoading => _loading;
+  AppError? get error => _error;
+
+  Future<void> load({String? status}) async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _projects = await _repository.fetchProjects(status: status);
+    } on AppError catch (error) {
+      _error = error;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/projects/projects_screen.dart
+++ b/lib/features/projects/projects_screen.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/errors/app_error.dart';
+import '../../domain/projects/project.dart';
+import '../../domain/projects/projects_repository.dart';
+import 'projects_controller.dart';
+
+class ProjectsScreen extends StatefulWidget {
+  const ProjectsScreen({super.key});
+
+  @override
+  State<ProjectsScreen> createState() => _ProjectsScreenState();
+}
+
+class _ProjectsScreenState extends State<ProjectsScreen> {
+  late final ProjectsController _controller;
+  String? _status;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ProjectsController(context.read<ProjectsRepository>())
+      ..addListener(_onUpdate)
+      ..load();
+  }
+
+  void _onUpdate() => setState(() {});
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onUpdate);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Proyectos'),
+        actions: [
+          PopupMenuButton<String?>(
+            initialValue: _status,
+            onSelected: (value) {
+              setState(() => _status = value);
+              _controller.load(status: value);
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: null, child: Text('Todos')),
+              PopupMenuItem(value: 'planned', child: Text('Planificados')),
+              PopupMenuItem(value: 'active', child: Text('Activos')),
+              PopupMenuItem(value: 'paused', child: Text('Pausados')),
+              PopupMenuItem(value: 'completed', child: Text('Completados')),
+            ],
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: _Content(controller: _controller),
+      ),
+    );
+  }
+}
+
+class _Content extends StatelessWidget {
+  const _Content({required this.controller});
+
+  final ProjectsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (controller.isLoading) {
+      return const _Skeleton();
+    }
+    if (controller.error != null) {
+      return _ErrorState(error: controller.error!, onRetry: controller.load);
+    }
+    final projects = controller.projects;
+    if (projects.isEmpty) {
+      return _EmptyState(onRetry: controller.load);
+    }
+    return RefreshIndicator(
+      onRefresh: controller.load,
+      child: ListView.builder(
+        itemCount: projects.length,
+        itemBuilder: (context, index) {
+          final project = projects[index];
+          return Card(
+            child: ListTile(
+              title: Text(project.name),
+              subtitle: Text('${project.status.name} • ${project.progressPct}%'),
+              trailing: Text(
+                '${project.startAt.toLocal().toIso8601String().substring(0, 10)}'
+                '${project.endAt != null ? ' → ${project.endAt!.toLocal().toIso8601String().substring(0, 10)}' : ''}',
+                style: const TextStyle(fontSize: 12),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _Skeleton extends StatelessWidget {
+  const _Skeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: 4,
+      itemBuilder: (context, index) => const ListTile(
+        leading: CircleAvatar(backgroundColor: Colors.grey),
+        title: SizedBox(height: 12, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+        subtitle: SizedBox(height: 10, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onRetry});
+
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('No hay proyectos disponibles'),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Actualizar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.error, required this.onRetry});
+
+  final AppError error;
+  final Future<void> Function({String? status}) onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(error.message),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => onRetry(),
+            child: const Text('Reintentar'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/tools/tools_controller.dart
+++ b/lib/features/tools/tools_controller.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+import '../../core/errors/app_error.dart';
+import '../../domain/tools/tool.dart';
+import '../../domain/tools/tools_repository.dart';
+
+class ToolsController extends ChangeNotifier {
+  ToolsController(this._repository);
+
+  final ToolsRepository _repository;
+
+  List<Tool> _tools = <Tool>[];
+  bool _loading = false;
+  AppError? _error;
+
+  List<Tool> get tools => _tools;
+  bool get isLoading => _loading;
+  AppError? get error => _error;
+
+  Future<void> load({String? status}) async {
+    _loading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _tools = await _repository.fetchTools(status: status);
+    } on AppError catch (error) {
+      _error = error;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/tools/tools_screen.dart
+++ b/lib/features/tools/tools_screen.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/errors/app_error.dart';
+import '../../domain/tools/tool.dart';
+import '../../domain/tools/tools_repository.dart';
+import 'tools_controller.dart';
+
+class ToolsScreen extends StatefulWidget {
+  const ToolsScreen({super.key});
+
+  @override
+  State<ToolsScreen> createState() => _ToolsScreenState();
+}
+
+class _ToolsScreenState extends State<ToolsScreen> {
+  late final ToolsController _controller;
+  String? _filter;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ToolsController(context.read<ToolsRepository>())
+      ..addListener(_onUpdate)
+      ..load();
+  }
+
+  void _onUpdate() => setState(() {});
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onUpdate);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Herramientas'),
+        actions: [
+          PopupMenuButton<String?>(
+            initialValue: _filter,
+            onSelected: (value) {
+              setState(() => _filter = value);
+              _controller.load(status: value);
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: null, child: Text('Todas')),
+              PopupMenuItem(value: 'available', child: Text('Disponibles')),
+              PopupMenuItem(value: 'in_use', child: Text('En uso')),
+              PopupMenuItem(value: 'missing', child: Text('Faltantes')),
+            ],
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: _Content(controller: _controller),
+      ),
+    );
+  }
+}
+
+class _Content extends StatelessWidget {
+  const _Content({required this.controller});
+
+  final ToolsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (controller.isLoading) {
+      return const _Skeleton();
+    }
+    if (controller.error != null) {
+      return _ErrorState(error: controller.error!, onRetry: controller.load);
+    }
+    final tools = controller.tools;
+    if (tools.isEmpty) {
+      return _EmptyState(onRetry: controller.load);
+    }
+    return RefreshIndicator(
+      onRefresh: controller.load,
+      child: ListView.builder(
+        itemCount: tools.length,
+        itemBuilder: (context, index) {
+          final tool = tools[index];
+          return Card(
+            child: ListTile(
+              leading: Icon(_iconForStatus(tool.status)),
+              title: Text(tool.name),
+              subtitle: Text('${tool.sku} • ${tool.location}'),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  IconData _iconForStatus(ToolStatus status) {
+    switch (status) {
+      case ToolStatus.available:
+        return Icons.check_circle_outline;
+      case ToolStatus.inUse:
+        return Icons.build_circle;
+      case ToolStatus.missing:
+        return Icons.warning_amber;
+    }
+  }
+}
+
+class _Skeleton extends StatelessWidget {
+  const _Skeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: 4,
+      itemBuilder: (context, index) => const ListTile(
+        leading: CircleAvatar(backgroundColor: Colors.grey),
+        title: SizedBox(height: 12, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+        subtitle: SizedBox(height: 10, child: DecoratedBox(decoration: BoxDecoration(color: Colors.grey))),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onRetry});
+
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('No hay herramientas registradas'),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: onRetry,
+            child: const Text('Actualizar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.error, required this.onRetry});
+
+  final AppError error;
+  final Future<void> Function({String? status}) onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(error.message),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => onRetry(),
+            child: const Text('Reintentar'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,17 +15,20 @@ dependencies:
   
   # State Management
   provider: ^6.1.1
-  
+
   # HTTP & API
   http: ^1.5.0
-  
+  dio: ^5.4.0
+
   # Storage & Cache
   shared_preferences: ^2.2.2
-  
+  isar: ^3.1.0+1
+  isar_flutter_libs: ^3.1.0+1
+
   # Web Support
   flutter_web_plugins:
     sdk: flutter
-  
+
   # Firebase
   firebase_core: ^2.24.2
   firebase_auth: ^4.15.3
@@ -34,24 +37,24 @@ dependencies:
   firebase_analytics: ^10.7.4
   firebase_remote_config: ^4.3.8
   cloud_functions: ^4.5.8
-  
+
   # Payments
   flutter_stripe: ^12.0.2
-  
+
   # Routing
   go_router: ^16.2.1
-  
+
   # Localization
   flutter_localizations:
     sdk: flutter
-  
+
   # Environment & Config
   flutter_dotenv: ^6.0.0
-  
+
   # UI Components
   flutter_svg: ^2.0.9
   shimmer: ^3.0.0
-  
+
   # Utils
   uuid: ^4.2.1
   firebase_crashlytics: ^3.5.7
@@ -63,6 +66,12 @@ dependencies:
   health: ^13.1.4
   get_it: ^8.2.0
   just_audio: ^0.10.4
+  connectivity_plus: ^6.0.3
+  path_provider: ^2.1.2
+  web_socket_channel: ^2.4.0
+  json_annotation: ^4.8.1
+  collection: ^1.18.0
+  crypto: ^3.0.3
 
 dev_dependencies:
   flutter_test:
@@ -71,6 +80,8 @@ dev_dependencies:
   mockito: ^5.5.0
   test: ^1.26.2
   mocktail: ^1.0.4
+  build_runner: ^2.4.9
+  isar_generator: ^3.1.0+1
 
 flutter:
   uses-material-design: true

--- a/test/core/outbox_service_test.dart
+++ b/test/core/outbox_service_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:mindcare/core/config/app_config.dart';
+import 'package:mindcare/core/logging/app_logger.dart';
+import 'package:mindcare/core/offline/outbox_service.dart';
+import 'package:mindcare/core/offline/outbox_task.dart';
+import 'package:mindcare/core/database/entities.dart';
+
+class MockExecutor extends Mock implements OutboxNetworkExecutor {}
+
+void main() {
+  late Isar isar;
+  late OutboxService service;
+  late MockExecutor executor;
+  late AppConfig config;
+
+  setUp(() async {
+    isar = await Isar.open(
+      [CachedEntitySchema, OutboxTaskSchema],
+      directory: Isar.inMemoryDirectory,
+      name: 'test',
+    );
+    executor = MockExecutor();
+    config = AppConfig.custom(
+      environment: AppEnvironment.dev,
+      baseUrl: 'https://example.com',
+      wsUrl: 'wss://example.com/ws',
+    );
+    service = OutboxService(
+      isar,
+      executor,
+      config,
+      AppLogger.instance,
+    );
+  });
+
+  tearDown(() async {
+    await isar.close(deleteFromDisk: true);
+  });
+
+  test('enqueue stores task', () async {
+    await service.enqueue(method: 'POST', endpoint: '/test', body: {'a': 1});
+    final tasks = await service.allTasks();
+    expect(tasks.length, 1);
+  });
+
+  test('processPending executes tasks', () async {
+    await service.enqueue(method: 'POST', endpoint: '/test');
+    when(() => executor.execute(any())).thenAnswer((_) async {});
+
+    await service.processPending();
+
+    final tasks = await service.allTasks();
+    expect(tasks.first.status, OutboxStatus.completed);
+  });
+}

--- a/test/data/alerts_repository_impl_test.dart
+++ b/test/data/alerts_repository_impl_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:mindcare/core/config/app_config.dart';
+import 'package:mindcare/core/errors/app_error.dart';
+import 'package:mindcare/core/logging/app_logger.dart';
+import 'package:mindcare/core/offline/outbox_service.dart';
+import 'package:mindcare/data/alerts/alerts_repository_impl.dart';
+import 'package:mindcare/data/alerts/datasources/alerts_local_data_source.dart';
+import 'package:mindcare/data/alerts/datasources/alerts_remote_data_source.dart';
+import 'package:mindcare/data/alerts/models/alert_dto.dart';
+import 'package:mindcare/core/offline/outbox_task.dart';
+
+class MockAlertsRemote extends Mock implements AlertsRemoteDataSource {}
+
+class MockAlertsLocal extends Mock implements AlertsLocalDataSource {}
+
+class MockOutboxService extends Mock implements OutboxService {}
+
+void main() {
+  group('AlertsRepositoryImpl', () {
+    late AlertsRepositoryImpl repository;
+    late MockAlertsRemote remote;
+    late MockAlertsLocal local;
+    late MockOutboxService outbox;
+    late AppConfig config;
+
+    setUp(() {
+      remote = MockAlertsRemote();
+      local = MockAlertsLocal();
+      outbox = MockOutboxService();
+      config = AppConfig.custom(
+        environment: AppEnvironment.dev,
+        baseUrl: 'https://example.com',
+        wsUrl: 'wss://example.com/ws',
+      );
+      repository = AlertsRepositoryImpl(
+        remote,
+        local,
+        config,
+        outbox,
+        AppLogger.instance,
+      );
+      when(() => local.loadAlerts()).thenAnswer((_) async => []);
+      registerFallbackValue(<String, dynamic>{});
+    });
+
+    test('fetchAlerts returns remote data and caches', () async {
+      final dto = AlertDto.fromJson({
+        'id': '1',
+        'type': 'Test',
+        'severity': 'high',
+        'source': 'system',
+        'createdAt': DateTime.now().toIso8601String(),
+      });
+      when(() => remote.fetchAlerts(any())).thenAnswer((_) async => [dto]);
+      when(() => local.cacheAlerts(any())).thenAnswer((_) async {});
+
+      final alerts = await repository.fetchAlerts();
+
+      expect(alerts, isNotEmpty);
+      verify(() => local.cacheAlerts(any())).called(1);
+    });
+
+    test('resolveAlert queues outbox on network error', () async {
+      final dto = AlertDto.fromJson({
+        'id': '1',
+        'type': 'Test',
+        'severity': 'high',
+        'source': 'system',
+        'createdAt': DateTime.now().toIso8601String(),
+      });
+      when(() => remote.getAlert('1')).thenAnswer((_) async => dto);
+      when(() => remote.resolveAlert('1')).thenThrow(
+        const AppError(AppErrorCode.networkUnreachable, 'offline'),
+      );
+      when(() => local.upsertAlert(any())).thenAnswer((_) async {});
+      when(() => outbox.enqueue(
+            method: any(named: 'method'),
+            endpoint: any(named: 'endpoint'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            reference: any(named: 'reference'),
+            retryAt: any(named: 'retryAt'),
+          )).thenAnswer((_) async => OutboxTask());
+
+      await repository.resolveAlert('1');
+
+      verify(() => outbox.enqueue(
+            method: 'POST',
+            endpoint: '/alerts/1/resolve',
+            body: const {},
+          )).called(1);
+    });
+  });
+}

--- a/test/data/auth_repository_impl_test.dart
+++ b/test/data/auth_repository_impl_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:mindcare/core/config/app_config.dart';
+import 'package:mindcare/core/errors/app_error.dart';
+import 'package:mindcare/core/logging/app_logger.dart';
+import 'package:mindcare/data/auth/auth_repository_impl.dart';
+import 'package:mindcare/data/auth/datasources/auth_local_data_source.dart';
+import 'package:mindcare/data/auth/datasources/auth_remote_data_source.dart';
+import 'package:mindcare/data/auth/models/auth_response_dto.dart';
+import 'package:mindcare/data/auth/models/refresh_response_dto.dart';
+import 'package:mindcare/data/auth/models/user_dto.dart';
+import 'package:mindcare/domain/auth/entities/app_user.dart';
+import 'package:mindcare/domain/auth/entities/auth_session.dart';
+
+class MockAuthRemoteDataSource extends Mock implements AuthRemoteDataSource {}
+
+class MockAuthLocalDataSource extends Mock implements AuthLocalDataSource {}
+
+void main() {
+  group('AuthRepositoryImpl', () {
+    late AuthRepositoryImpl repository;
+    late MockAuthRemoteDataSource remote;
+    late MockAuthLocalDataSource local;
+    late AppConfig config;
+
+    setUp(() {
+      remote = MockAuthRemoteDataSource();
+      local = MockAuthLocalDataSource();
+      config = AppConfig.custom(
+        environment: AppEnvironment.dev,
+        baseUrl: 'https://example.com',
+        wsUrl: 'wss://example.com/ws',
+      );
+      repository = AuthRepositoryImpl(
+        config,
+        remote,
+        local,
+        AppLogger.instance,
+      );
+      registerFallbackValue(SessionTokens(token: '', refreshToken: ''));
+    });
+
+    test('login stores tokens and returns session', () async {
+      when(() => remote.login(username: any(named: 'username'), password: any(named: 'password')))
+          .thenAnswer((_) async => AuthResponseDto.fromJson({
+                'token': 'token',
+                'refreshToken': 'refresh',
+                'user': {
+                  'id': '1',
+                  'username': 'user',
+                  'displayName': 'User',
+                  'role': 'admin',
+                },
+              }));
+      when(() => local.saveTokens(any())).thenAnswer((_) async {});
+
+      final session = await repository.login(username: 'user', password: 'pass');
+
+      expect(session.user.username, 'user');
+      verify(() => local.saveTokens(any())).called(1);
+    });
+
+    test('refresh token updates local storage', () async {
+      when(() => local.readTokens())
+          .thenAnswer((_) async => SessionTokens(token: 't', refreshToken: 'refresh'));
+      when(() => remote.refresh(any())).thenAnswer(
+        (_) async => RefreshResponseDto(token: 'new', refreshToken: 'new-refresh'),
+      );
+      when(() => local.saveTokens(any())).thenAnswer((_) async {});
+
+      final result = await repository.refreshToken();
+
+      expect(result, isTrue);
+      verify(() => local.saveTokens(any())).called(1);
+    });
+
+    test('refresh user retries after unauthorized', () async {
+      when(() => remote.fetchMe())
+          .thenThrow(const AppError(AppErrorCode.unauthorized, 'unauthorized'))
+          .thenAnswer((_) async => UserDto.fromJson({
+                'id': '1',
+                'username': 'user',
+                'displayName': 'User',
+                'role': 'admin',
+              }));
+      when(() => local.readTokens())
+          .thenAnswer((_) async => SessionTokens(token: 't', refreshToken: 'r'));
+      when(() => remote.refresh(any()))
+          .thenAnswer((_) async => RefreshResponseDto(token: 'x', refreshToken: 'y'));
+      when(() => local.saveTokens(any())).thenAnswer((_) async {});
+
+      when(() => remote.login(username: any(named: 'username'), password: any(named: 'password')))
+          .thenAnswer((_) async => AuthResponseDto.fromJson({
+                'token': 'token',
+                'refreshToken': 'refresh',
+                'user': {
+                  'id': '1',
+                  'username': 'user',
+                  'displayName': 'User',
+                  'role': 'admin',
+                },
+              }));
+      when(() => local.saveTokens(any())).thenAnswer((_) async {});
+
+      await repository.login(username: 'user', password: 'pass');
+
+      await repository.refreshUser();
+
+      verify(() => remote.refresh(any())).called(1);
+    });
+  });
+}

--- a/test/data/fuel_repository_impl_test.dart
+++ b/test/data/fuel_repository_impl_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:mindcare/core/config/app_config.dart';
+import 'package:mindcare/core/errors/app_error.dart';
+import 'package:mindcare/core/logging/app_logger.dart';
+import 'package:mindcare/core/offline/outbox_service.dart';
+import 'package:mindcare/core/offline/outbox_task.dart';
+import 'package:mindcare/data/fuel/datasources/fuel_local_data_source.dart';
+import 'package:mindcare/data/fuel/datasources/fuel_remote_data_source.dart';
+import 'package:mindcare/data/fuel/fuel_repository_impl.dart';
+import 'package:mindcare/data/fuel/models/fuel_event_dto.dart';
+import 'package:mindcare/domain/fuel/fuel_event.dart';
+
+class MockFuelRemoteDataSource extends Mock implements FuelRemoteDataSource {}
+
+class MockFuelLocalDataSource extends Mock implements FuelLocalDataSource {}
+
+class MockOutboxService extends Mock implements OutboxService {}
+
+void main() {
+  group('FuelRepositoryImpl', () {
+    late FuelRepositoryImpl repository;
+    late MockFuelRemoteDataSource remote;
+    late MockFuelLocalDataSource local;
+    late MockOutboxService outbox;
+    late AppConfig config;
+
+    setUp(() {
+      remote = MockFuelRemoteDataSource();
+      local = MockFuelLocalDataSource();
+      outbox = MockOutboxService();
+      config = AppConfig.custom(
+        environment: AppEnvironment.dev,
+        baseUrl: 'https://example.com',
+        wsUrl: 'wss://example.com/ws',
+      );
+      repository = FuelRepositoryImpl(
+        remote,
+        local,
+        config,
+        outbox,
+        AppLogger.instance,
+      );
+      when(() => local.loadEvents()).thenAnswer((_) async => []);
+    });
+
+    test('fetchEvents caches remote data', () async {
+      when(() => remote.fetchEvents(any())).thenAnswer((_) async => [
+            FuelEventDto.fromDomain(
+              FuelEvent(
+                id: '1',
+                vehicleId: 'v1',
+                operatorId: 'o1',
+                liters: 10,
+                timestamp: DateTime.now(),
+                source: FuelSource.manual,
+              ),
+            ),
+          ]);
+      when(() => local.cacheEvents(any())).thenAnswer((_) async {});
+
+      final events = await repository.fetchEvents();
+
+      expect(events, isNotEmpty);
+      verify(() => local.cacheEvents(any())).called(1);
+    });
+
+    test('createEvent queues outbox on network error', () async {
+      final event = FuelEvent(
+        id: '',
+        vehicleId: 'truck-1',
+        operatorId: 'op-1',
+        liters: 50,
+        timestamp: DateTime.now(),
+        source: FuelSource.manual,
+      );
+      when(() => remote.createEvent(any())).thenThrow(
+        const AppError(AppErrorCode.networkUnreachable, 'offline'),
+      );
+      when(() => local.cacheEvents(any())).thenAnswer((_) async {});
+      when(() => outbox.enqueue(
+            method: any(named: 'method'),
+            endpoint: any(named: 'endpoint'),
+            body: any(named: 'body'),
+            headers: any(named: 'headers'),
+            reference: any(named: 'reference'),
+            retryAt: any(named: 'retryAt'),
+          )).thenAnswer((_) async => OutboxTask());
+
+      await repository.createEvent(event);
+
+      verify(() => outbox.enqueue(
+            method: 'POST',
+            endpoint: '/fuel/events',
+            body: any(named: 'body'),
+            reference: any(named: 'reference'),
+          )).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- wire up fuel, tools, operators, projects, reports and admin repositories with cache/offline support and file saving utilities
- add list screens for the new modules, upgrade dashboard metrics and enrich admin users flow with creation/disable actions
- document the connected modules and metrics in the README and cover fuel repository behaviour with unit tests

## Testing
- unable to run `flutter test` (flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9ad0ecd04832cb910ad0b19a04fa0